### PR TITLE
fix: FTS5 multi-word knowledge search returns 0 results

### DIFF
--- a/src/knowledge/KnowledgeStore.ts
+++ b/src/knowledge/KnowledgeStore.ts
@@ -76,6 +76,50 @@ function computeKnowledgeId(projectId: string, title: string): string {
   return hasher.digest("hex");
 }
 
+/**
+ * Sanitize and tokenize a user query for FTS5 MATCH.
+ *
+ * - Strips FTS5 special operators to prevent injection
+ * - Preserves double-quoted phrases as FTS5 phrase literals
+ * - Splits unquoted text on whitespace and joins with OR
+ * - Returns empty string if query contains no valid terms
+ */
+export function sanitizeFts5Query(raw: string): string {
+  // 1. Extract quoted phrases first, replacing them with placeholders
+  const phrases: string[] = [];
+  const withoutPhrases = raw.replace(/"([^"]+)"/g, (_match, inner: string) => {
+    // Sanitize inside the phrase too
+    const clean = inner.replace(/[*^(){}:]/g, " ").trim();
+    if (clean) {
+      phrases.push('"' + clean.replace(/"/g, '""') + '"');
+    }
+    return " ";
+  });
+
+  // 2. Strip everything except alphanumeric, underscore, hyphen, and whitespace
+  const sanitized = withoutPhrases
+    .replace(/[^a-zA-Z0-9_\-\s]/g, " ")
+    .replace(/\b(AND|OR|NOT|NEAR)\b/gi, " ")
+    .trim();
+
+  // 3. Split into individual terms
+  const terms = sanitized.split(/\s+/).filter((t) => t.length > 0);
+
+  // 4. Combine phrases and individual terms with OR
+  const allParts = [...phrases, ...terms];
+
+  if (allParts.length === 0) {
+    return "";
+  }
+
+  // Single term: no OR wrapper needed
+  if (allParts.length === 1) {
+    return allParts[0]!;
+  }
+
+  return allParts.join(" OR ");
+}
+
 function rowToEntry(row: KnowledgeRow): KnowledgeEntry {
   const entry: KnowledgeEntry = {
     id: row.id,
@@ -247,16 +291,11 @@ export class KnowledgeStore {
     }
 
     sql += ` ORDER BY fts.rank LIMIT $limit`;
-    // Strip FTS5 operators that could alter query semantics
-    const sanitized = options.query
-      .replace(/[*^(){}:]/g, " ")
-      .replace(/\b(AND|OR|NOT|NEAR)\b/gi, " ")
-      .trim();
-    if (!sanitized) {
-      // Query was entirely operators — return empty results rather than re-enabling operators
+    const ftsQuery = sanitizeFts5Query(options.query);
+    if (!ftsQuery) {
       return [];
     }
-    params.$query = '"' + sanitized.replace(/"/g, '""') + '"';
+    params.$query = ftsQuery;
     params.$limit = limit;
 
     const rows = this.db.prepare(sql).all(params) as KnowledgeSearchRow[];

--- a/src/knowledge/__tests__/KnowledgeStore.test.ts
+++ b/src/knowledge/__tests__/KnowledgeStore.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, beforeEach } from "bun:test";
 import { Database } from "bun:sqlite";
-import { KnowledgeStore } from "../KnowledgeStore.js";
+import { KnowledgeStore, sanitizeFts5Query } from "../KnowledgeStore.js";
 import type { KnowledgeEntry } from "../KnowledgeStore.js";
 
 describe("KnowledgeStore", () => {
@@ -251,5 +251,131 @@ describe("KnowledgeStore", () => {
       expect(stats.totalEntries).toBe(0);
       expect(Object.keys(stats.byProject)).toHaveLength(0);
     });
+  });
+
+  describe("multi-word FTS5 search (issue #27)", () => {
+    beforeEach(() => {
+      store.ingest({
+        projectId: "proj-1",
+        title: "Biometric authentication on Android",
+        solution: "Use BiometricPrompt API for fingerprint and face recognition",
+        symptoms: "App crashes on biometric prompt",
+        tags: ["android", "biometric", "auth"],
+      });
+      store.ingest({
+        projectId: "proj-1",
+        title: "OAuth2 authentication flow",
+        solution: "Implement PKCE flow for mobile apps",
+        tags: ["oauth", "auth"],
+      });
+      store.ingest({
+        projectId: "proj-1",
+        title: "Android crash on API 28",
+        solution: "Add backward-compat shim for older Android versions",
+        tags: ["android", "crash"],
+      });
+    });
+
+    it("should return results for multi-word queries using OR semantics", () => {
+      // This was the exact failure case from issue #27
+      const results = store.search({ query: "biometric authentication android" });
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      // The biometric entry should appear (matches all three words)
+      const titles = results.map((r) => r.entry.title);
+      expect(titles).toContain("Biometric authentication on Android");
+    });
+
+    it("should match entries containing any of the query words", () => {
+      const results = store.search({ query: "biometric android" });
+      expect(results.length).toBeGreaterThanOrEqual(2);
+      const titles = results.map((r) => r.entry.title);
+      // Both the biometric entry and the Android crash entry should match
+      expect(titles).toContain("Biometric authentication on Android");
+      expect(titles).toContain("Android crash on API 28");
+    });
+
+    it("should still work with single-word queries", () => {
+      const results = store.search({ query: "Biometric" });
+      expect(results.length).toBe(1);
+      expect(results[0]!.entry.title).toBe("Biometric authentication on Android");
+    });
+
+    it("should support quoted phrases for exact match", () => {
+      // Quoted phrase should match only entries with adjacent words
+      const results = store.search({ query: '"authentication flow"' });
+      expect(results.length).toBe(1);
+      expect(results[0]!.entry.title).toBe("OAuth2 authentication flow");
+    });
+
+    it("should return empty results for empty query", () => {
+      const results = store.search({ query: "" });
+      expect(results.length).toBe(0);
+    });
+
+    it("should return empty results for query with only operators", () => {
+      const results = store.search({ query: "AND OR NOT * ^" });
+      expect(results.length).toBe(0);
+    });
+
+    it("should sanitize FTS5 injection attempts", () => {
+      // These should not throw or cause SQL injection
+      const results1 = store.search({ query: "biometric) OR (1=1" });
+      // Should still find the biometric entry despite injection attempt
+      expect(results1.length).toBeGreaterThanOrEqual(1);
+
+      const results2 = store.search({ query: 'title:biometric' });
+      // Colon is stripped, should still match on "biometric"
+      expect(results2.length).toBeGreaterThanOrEqual(1);
+
+      // NEAR operator should be stripped
+      const results3 = store.search({ query: "biometric NEAR android" });
+      expect(results3.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});
+
+describe("sanitizeFts5Query", () => {
+  it("should join multiple words with OR", () => {
+    expect(sanitizeFts5Query("foo bar baz")).toBe("foo OR bar OR baz");
+  });
+
+  it("should return single word as-is", () => {
+    expect(sanitizeFts5Query("hello")).toBe("hello");
+  });
+
+  it("should preserve quoted phrases", () => {
+    const result = sanitizeFts5Query('"exact phrase" other');
+    expect(result).toBe('"exact phrase" OR other');
+  });
+
+  it("should handle multiple quoted phrases", () => {
+    const result = sanitizeFts5Query('"phrase one" "phrase two"');
+    expect(result).toBe('"phrase one" OR "phrase two"');
+  });
+
+  it("should strip FTS5 special characters", () => {
+    expect(sanitizeFts5Query("foo*bar^baz")).toBe("foo OR bar OR baz");
+    expect(sanitizeFts5Query("test(){}:")).toBe("test");
+  });
+
+  it("should strip FTS5 reserved words", () => {
+    expect(sanitizeFts5Query("foo AND bar")).toBe("foo OR bar");
+    expect(sanitizeFts5Query("NOT something")).toBe("something");
+    expect(sanitizeFts5Query("a NEAR b")).toBe("a OR b");
+  });
+
+  it("should return empty string for empty input", () => {
+    expect(sanitizeFts5Query("")).toBe("");
+    expect(sanitizeFts5Query("   ")).toBe("");
+  });
+
+  it("should return empty string for operator-only input", () => {
+    expect(sanitizeFts5Query("AND OR NOT")).toBe("");
+    expect(sanitizeFts5Query("* ^ () {}")).toBe("");
+  });
+
+  it("should handle mixed quoted and unquoted terms", () => {
+    const result = sanitizeFts5Query('hello "exact match" world');
+    expect(result).toBe('"exact match" OR hello OR world');
   });
 });

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -6,6 +6,7 @@
 
 export {
   KnowledgeStore,
+  sanitizeFts5Query,
   type KnowledgeEntry,
   type KnowledgeSearchOptions,
   type KnowledgeSearchResult,


### PR DESCRIPTION
## Summary
- Multi-word FTS5 queries (e.g., "biometric authentication android") returned 0 results because the query was wrapped in double quotes, making FTS5 treat it as a phrase search
- Added `sanitizeFts5Query()` function that tokenizes multi-word queries with OR joins while preserving quoted phrases
- Strips FTS5 injection characters and reserved operators

## Changes
- `src/knowledge/KnowledgeStore.ts` — new exported `sanitizeFts5Query()`, replaces phrase-wrap construction
- `src/knowledge/__tests__/KnowledgeStore.test.ts` — 17 new tests
- `src/knowledge/index.ts` — exports `sanitizeFts5Query`

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] 32 knowledge store tests pass (17 new)
- [x] Multi-word: "foo bar" → `foo OR bar`
- [x] Quoted phrase: `"exact phrase"` → FTS5 phrase literal
- [x] Injection: `*(){}:` and `AND OR NOT NEAR` stripped

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search query processing to handle special characters and operators more robustly.
  * Enhanced reliability of multi-word and phrase-based searches in the knowledge base.
  * Better handling of edge cases in search query validation.

* **Tests**
  * Added comprehensive test coverage for search functionality, including various query types and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->