### PR TITLE
feat: Replace n-gram hash vectorizer with BM25+TF-IDF for deterministic search quality

### DIFF
--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -40,12 +40,19 @@ export async function startHTTPServer(): Promise<void> {
   const runtimeConfig = loadRuntimeConfig();
   const services = await createRuntimeServices();
 
+  // Create BM25Scorer for deterministic search ranking
+  const { BM25Scorer } = await import("../search/BM25Scorer.js");
+  const { Database: BM25Database } = await import("bun:sqlite");
+  const bm25Db = new BM25Database(runtimeConfig.pingMem.dbPath === ":memory:" ? ":memory:" : runtimeConfig.pingMem.dbPath);
+  const bm25Scorer = new BM25Scorer(bm25Db);
+
   // Create IngestionService only when both Neo4j and Qdrant are available
   let ingestionService: IngestionService | undefined;
   if (services.neo4jClient && services.qdrantClient) {
     ingestionService = new IngestionService({
       neo4jClient: services.neo4jClient,
       qdrantClient: services.qdrantClient,
+      bm25Scorer,
     });
     // Ensure Neo4j uniqueness constraints exist before accepting any ingest requests.
     // MCP path calls this after construction; HTTP path must mirror that behaviour.

--- a/src/ingest/IngestionService.ts
+++ b/src/ingest/IngestionService.ts
@@ -34,6 +34,8 @@ export interface IngestionServiceOptions {
   qdrantClient: QdrantClientWrapper;
   eventStore?: EventStore;
   healthMonitor?: HealthMonitor;
+  /** BM25Scorer instance for primary ranking. Passed to CodeIndexer. */
+  bm25Scorer?: import("../search/BM25Scorer.js").BM25Scorer;
 }
 
 export interface IngestProjectOptions {
@@ -91,6 +93,7 @@ export class IngestionService {
     });
     this.codeIndexer = new CodeIndexer({
       qdrantClient: options.qdrantClient,
+      ...(options.bm25Scorer ? { bm25Scorer: options.bm25Scorer } : {}),
     });
     this.eventStore = options.eventStore ?? null;
     this.healthMonitor = options.healthMonitor ?? null;

--- a/src/mcp/PingMemServer.ts
+++ b/src/mcp/PingMemServer.ts
@@ -374,12 +374,19 @@ export async function main(): Promise<void> {
   const services = await createRuntimeServices();
   const diagnosticsDbPath = process.env.PING_MEM_DIAGNOSTICS_DB_PATH;
 
+  // Create BM25Scorer for deterministic search ranking
+  const { BM25Scorer } = await import("../search/BM25Scorer.js");
+  const { Database: BM25Database } = await import("bun:sqlite");
+  const bm25Db = new BM25Database(runtimeConfig.pingMem.dbPath === ":memory:" ? ":memory:" : runtimeConfig.pingMem.dbPath);
+  const bm25Scorer = new BM25Scorer(bm25Db);
+
   // Create IngestionService only when both Neo4j and Qdrant are available
   let ingestionService: IngestionService | undefined;
   if (services.neo4jClient && services.qdrantClient) {
     ingestionService = new IngestionService({
       neo4jClient: services.neo4jClient,
       qdrantClient: services.qdrantClient,
+      bm25Scorer,
     });
     try {
       await ingestionService.ensureConstraints();

--- a/src/search/BM25Scorer.ts
+++ b/src/search/BM25Scorer.ts
@@ -1,0 +1,212 @@
+/**
+ * BM25Scorer: Deterministic BM25+TF-IDF ranking with SQLite inverted index
+ *
+ * Replaces DeterministicVectorizer (n-gram hash) as the default ranker.
+ * Uses a proper inverted index stored in SQLite for deterministic, reproducible
+ * BM25 scoring with configurable k1 and b parameters.
+ *
+ * Same input -> same scores (deterministic).
+ *
+ * @module search/BM25Scorer
+ */
+
+import { Database } from "bun:sqlite";
+
+export interface BM25ScorerOptions {
+  /** BM25 k1 parameter — controls term frequency saturation (default: 1.5) */
+  k1?: number;
+  /** BM25 b parameter — controls document length normalization (default: 0.75) */
+  b?: number;
+}
+
+export interface BM25SearchResult {
+  chunkId: string;
+  score: number;
+}
+
+/**
+ * Tokenize text into lowercase terms, stripping punctuation.
+ * Deterministic: same text -> same tokens, always.
+ */
+export function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .filter((t) => t.length > 0);
+}
+
+/**
+ * BM25Scorer with SQLite-backed inverted index.
+ *
+ * Stores term -> [chunkId, tf] mappings in SQLite during ingestion.
+ * Computes IDF as log(1 + (N - df + 0.5) / (df + 0.5)) per the Lucene BM25 variant.
+ * Scores are fully deterministic: same corpus + same query = same results.
+ */
+export class BM25Scorer {
+  private readonly db: Database;
+  private readonly k1: number;
+  private readonly b: number;
+
+  private readonly insertTermStmt: ReturnType<Database["prepare"]>;
+  private readonly deleteChunkTermsStmt: ReturnType<Database["prepare"]>;
+  private readonly insertDocLenStmt: ReturnType<Database["prepare"]>;
+  private readonly deleteDocLenStmt: ReturnType<Database["prepare"]>;
+  private readonly getDocLenStmt: ReturnType<Database["prepare"]>;
+  private readonly getAvgDlStmt: ReturnType<Database["prepare"]>;
+  private readonly getDocCountStmt: ReturnType<Database["prepare"]>;
+  private readonly getDfStmt: ReturnType<Database["prepare"]>;
+  private readonly getTermPostingsStmt: ReturnType<Database["prepare"]>;
+
+  constructor(db: Database, options: BM25ScorerOptions = {}) {
+    this.db = db;
+    this.k1 = options.k1 ?? 1.5;
+    this.b = options.b ?? 0.75;
+
+    this.initTables();
+
+    this.insertTermStmt = this.db.prepare(
+      `INSERT OR REPLACE INTO bm25_inverted_index (term, chunk_id, tf) VALUES (?, ?, ?)`
+    );
+    this.deleteChunkTermsStmt = this.db.prepare(
+      `DELETE FROM bm25_inverted_index WHERE chunk_id = ?`
+    );
+    this.insertDocLenStmt = this.db.prepare(
+      `INSERT OR REPLACE INTO bm25_doc_lengths (chunk_id, doc_length) VALUES (?, ?)`
+    );
+    this.deleteDocLenStmt = this.db.prepare(
+      `DELETE FROM bm25_doc_lengths WHERE chunk_id = ?`
+    );
+    this.getDocLenStmt = this.db.prepare(
+      `SELECT doc_length FROM bm25_doc_lengths WHERE chunk_id = ?`
+    );
+    this.getAvgDlStmt = this.db.prepare(
+      `SELECT AVG(doc_length) as avg_dl FROM bm25_doc_lengths`
+    );
+    this.getDocCountStmt = this.db.prepare(
+      `SELECT COUNT(*) as cnt FROM bm25_doc_lengths`
+    );
+    this.getDfStmt = this.db.prepare(
+      `SELECT COUNT(DISTINCT chunk_id) as df FROM bm25_inverted_index WHERE term = ?`
+    );
+    this.getTermPostingsStmt = this.db.prepare(
+      `SELECT chunk_id, tf FROM bm25_inverted_index WHERE term = ?`
+    );
+  }
+
+  private initTables(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS bm25_inverted_index (
+        term TEXT NOT NULL, chunk_id TEXT NOT NULL, tf REAL NOT NULL,
+        PRIMARY KEY (term, chunk_id)
+      )
+    `);
+    this.db.exec(`CREATE INDEX IF NOT EXISTS idx_bm25_ii_term ON bm25_inverted_index (term)`);
+    this.db.exec(`CREATE INDEX IF NOT EXISTS idx_bm25_ii_chunk ON bm25_inverted_index (chunk_id)`);
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS bm25_doc_lengths (
+        chunk_id TEXT PRIMARY KEY, doc_length INTEGER NOT NULL
+      )
+    `);
+  }
+
+  indexDocument(chunkId: string, content: string): void {
+    const tokens = tokenize(content);
+    if (tokens.length === 0) return;
+    this.deleteChunkTermsStmt.run(chunkId);
+    this.deleteDocLenStmt.run(chunkId);
+    const tfMap = new Map<string, number>();
+    for (const token of tokens) {
+      tfMap.set(token, (tfMap.get(token) ?? 0) + 1);
+    }
+    this.insertDocLenStmt.run(chunkId, tokens.length);
+    for (const [term, tf] of tfMap.entries()) {
+      this.insertTermStmt.run(term, chunkId, tf);
+    }
+  }
+
+  removeDocument(chunkId: string): void {
+    this.deleteChunkTermsStmt.run(chunkId);
+    this.deleteDocLenStmt.run(chunkId);
+  }
+
+  removeDocuments(chunkIds: string[]): void {
+    const txn = this.db.transaction(() => {
+      for (const id of chunkIds) {
+        this.deleteChunkTermsStmt.run(id);
+        this.deleteDocLenStmt.run(id);
+      }
+    });
+    txn();
+  }
+
+  indexDocumentsBatch(docs: Array<{ chunkId: string; content: string }>): void {
+    const txn = this.db.transaction(() => {
+      for (const doc of docs) {
+        this.indexDocument(doc.chunkId, doc.content);
+      }
+    });
+    txn();
+  }
+
+  search(query: string, limit = 10, filterChunkIds?: Set<string>): BM25SearchResult[] {
+    const queryTokens = tokenize(query);
+    if (queryTokens.length === 0) return [];
+    const N = this.getDocumentCount();
+    if (N === 0) return [];
+    const avgDl = this.getAverageDocLength();
+    const uniqueTerms = [...new Set(queryTokens)];
+    const scores = new Map<string, number>();
+
+    for (const term of uniqueTerms) {
+      const df = this.getDocumentFrequency(term);
+      if (df === 0) continue;
+      const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5));
+      if (idf <= 0) continue;
+      const postings = this.getTermPostings(term);
+      for (const posting of postings) {
+        if (filterChunkIds && !filterChunkIds.has(posting.chunkId)) continue;
+        const docLen = this.getDocLength(posting.chunkId);
+        const tf = posting.tf;
+        const numerator = tf * (this.k1 + 1);
+        const denominator = tf + this.k1 * (1 - this.b + this.b * (docLen / avgDl));
+        const termScore = idf * (numerator / denominator);
+        scores.set(posting.chunkId, (scores.get(posting.chunkId) ?? 0) + termScore);
+      }
+    }
+
+    const results: BM25SearchResult[] = [];
+    for (const [chunkId, score] of scores.entries()) {
+      results.push({ chunkId, score });
+    }
+    results.sort((a, b) => b.score - a.score);
+    return results.slice(0, Math.max(1, Math.min(limit, 1000)));
+  }
+
+  getDocumentCount(): number {
+    const row = this.getDocCountStmt.get() as { cnt: number } | undefined;
+    return row?.cnt ?? 0;
+  }
+
+  getAverageDocLength(): number {
+    const row = this.getAvgDlStmt.get() as { avg_dl: number | null } | undefined;
+    return row?.avg_dl ?? 0;
+  }
+
+  getDocumentFrequency(term: string): number {
+    const row = this.getDfStmt.get(term) as { df: number } | undefined;
+    return row?.df ?? 0;
+  }
+
+  private getDocLength(chunkId: string): number {
+    const row = this.getDocLenStmt.get(chunkId) as { doc_length: number } | undefined;
+    return row?.doc_length ?? 0;
+  }
+
+  private getTermPostings(term: string): Array<{ chunkId: string; tf: number }> {
+    const rows = this.getTermPostingsStmt.all(term) as Array<{ chunk_id: string; tf: number }>;
+    return rows.map((r) => ({ chunkId: r.chunk_id, tf: r.tf }));
+  }
+}

--- a/src/search/CodeIndexer.ts
+++ b/src/search/CodeIndexer.ts
@@ -12,6 +12,7 @@
 
 import { QdrantClientWrapper } from "./QdrantClient.js";
 import { DeterministicVectorizer } from "./DeterministicVectorizer.js";
+import { BM25Scorer } from "./BM25Scorer.js";
 import type { CodeChunkStore } from "./CodeChunkStore.js";
 import { createLogger } from "../util/logger.js";
 import { sanitizeHealthError } from "../observability/health-probes.js";
@@ -19,13 +20,19 @@ import type { IngestionResult, CodeFileResult, ChunkWithId } from "../ingest/ind
 
 const log = createLogger("CodeIndexer");
 
-/** RRF constant (k parameter) — same as HybridSearchEngine */
+/** Hybrid mode weights: BM25 * 0.6 + dense * 0.4 */
+const BM25_WEIGHT = 0.6;
+const DENSE_WEIGHT = 0.4;
+
+/** RRF constant (k parameter) — used for RRF fallback and Qdrant-only mode */
 const RRF_K = 60;
 
 export interface CodeIndexerOptions {
   qdrantClient: QdrantClientWrapper;
   vectorizer?: DeterministicVectorizer;
   codeChunkStore?: CodeChunkStore;
+  /** BM25Scorer instance for primary ranking. */
+  bm25Scorer?: BM25Scorer;
 }
 
 export interface ChunkSearchResult {
@@ -43,11 +50,13 @@ export class CodeIndexer {
   private readonly qdrant: QdrantClientWrapper;
   private readonly vectorizer: DeterministicVectorizer;
   private readonly codeChunkStore: CodeChunkStore | undefined;
+  private readonly bm25Scorer: BM25Scorer | undefined;
 
   constructor(options: CodeIndexerOptions) {
     this.qdrant = options.qdrantClient;
     this.vectorizer = options.vectorizer ?? new DeterministicVectorizer();
     this.codeChunkStore = options.codeChunkStore;
+    this.bm25Scorer = options.bm25Scorer;
   }
 
   /**
@@ -55,6 +64,19 @@ export class CodeIndexer {
    * Idempotent: can be called multiple times for the same chunkId.
    */
   async indexIngestion(result: IngestionResult): Promise<void> {
+    // Index into BM25Scorer inverted index
+    if (this.bm25Scorer) {
+      const docs: Array<{ chunkId: string; content: string }> = [];
+      for (const fileResult of result.codeFiles) {
+        for (const chunk of fileResult.chunks) {
+          docs.push({ chunkId: chunk.chunkId, content: chunk.content });
+        }
+      }
+      if (docs.length > 0) {
+        this.bm25Scorer.indexDocumentsBatch(docs);
+      }
+    }
+
     const points = this.buildIndexPoints(result);
 
     if (points.length > 0) {
@@ -141,11 +163,56 @@ export class CodeIndexer {
       limit?: number;
     } = {}
   ): Promise<ChunkSearchResult[]> {
-    // If CodeChunkStore is available, do RRF merge
+    // Strategy 1: BM25Scorer is the primary ranker
+    if (this.bm25Scorer) {
+      // BM25-only search (metadata from CodeChunkStore or Qdrant)
+      const clampedLimit = Math.max(1, Math.min(Math.floor(options.limit ?? 10), 1000));
+      const fetchLimit = Math.min(clampedLimit * 3, 300);
+      const bm25Results = this.bm25Scorer.search(query, fetchLimit);
+      let qdrantResults: ChunkSearchResult[] = [];
+      try { qdrantResults = await this.searchQdrantOnly(query, { ...options, limit: fetchLimit }); } catch {}
+      const metaLookup = new Map<string, ChunkSearchResult>();
+      for (const r of qdrantResults) metaLookup.set(r.chunkId, r);
+      if (this.codeChunkStore) {
+        for (const r of this.codeChunkStore.search(query, options.projectId, fetchLimit)) {
+          if (!metaLookup.has(r.chunkId)) {
+            metaLookup.set(r.chunkId, { chunkId: r.chunkId, projectId: r.projectId, filePath: r.filePath, type: "code", content: r.content, lineStart: r.startLine, lineEnd: r.endLine, score: 0 });
+          }
+        }
+      }
+      if (qdrantResults.length > 0) {
+        const bm25S = new Map(bm25Results.map(r => [r.chunkId, r.score]));
+        const denseS = new Map(qdrantResults.map(r => [r.chunkId, r.score]));
+        const bv = [...bm25S.values()]; const bMin = bv.length ? Math.min(...bv) : 0; const bRng = (bv.length ? Math.max(...bv) : 0) - bMin || 1;
+        const dv = [...denseS.values()]; const dMin = dv.length ? Math.min(...dv) : 0; const dRng = (dv.length ? Math.max(...dv) : 0) - dMin || 1;
+        const allIds = new Set([...bm25S.keys(), ...denseS.keys()]);
+        const scored: Array<{ chunkId: string; score: number }> = [];
+        for (const id of allIds) {
+          const m = metaLookup.get(id); if (!m) continue;
+          if (options.projectId && m.projectId !== options.projectId) continue;
+          const bn = bm25S.has(id) ? (bm25S.get(id)! - bMin) / bRng : 0;
+          const dn = denseS.has(id) ? (denseS.get(id)! - dMin) / dRng : 0;
+          scored.push({ chunkId: id, score: bn * BM25_WEIGHT + dn * DENSE_WEIGHT });
+        }
+        scored.sort((a, b) => b.score - a.score);
+        return scored.slice(0, clampedLimit).map(s => ({ ...metaLookup.get(s.chunkId)!, score: s.score }));
+      }
+      const results: ChunkSearchResult[] = [];
+      for (const bm25 of bm25Results) {
+        const meta = metaLookup.get(bm25.chunkId); if (!meta) continue;
+        if (options.projectId && meta.projectId !== options.projectId) continue;
+        results.push({ ...meta, score: bm25.score });
+        if (results.length >= clampedLimit) break;
+      }
+      return results;
+    }
+
+    // Strategy 2: CodeChunkStore FTS5 + Qdrant RRF (legacy)
     if (this.codeChunkStore) {
       return this.searchWithRRF(query, options);
     }
 
+    // Strategy 3: Qdrant only (legacy fallback)
     return this.searchQdrantOnly(query, options);
   }
 

--- a/src/search/__tests__/BM25Scorer.test.ts
+++ b/src/search/__tests__/BM25Scorer.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { BM25Scorer, tokenize } from "../BM25Scorer.js";
+import { Database } from "bun:sqlite";
+
+describe("BM25Scorer", () => {
+  let db: Database;
+  let scorer: BM25Scorer;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    scorer = new BM25Scorer(db);
+  });
+
+  afterEach(() => { db.close(); });
+
+  describe("tokenize", () => {
+    it("should lowercase and split", () => { expect(tokenize("Hello World")).toEqual(["hello", "world"]); });
+    it("should strip punctuation", () => { expect(tokenize("foo.bar(baz)")).toEqual(["foo", "bar", "baz"]); });
+    it("should return empty for empty", () => { expect(tokenize("")).toEqual([]); });
+  });
+
+  describe("indexDocument", () => {
+    it("should index and update count", () => {
+      scorer.indexDocument("c1", "hello world test");
+      expect(scorer.getDocumentCount()).toBe(1);
+    });
+    it("should be idempotent", () => {
+      scorer.indexDocument("c1", "hello world");
+      scorer.indexDocument("c1", "goodbye world");
+      expect(scorer.getDocumentCount()).toBe(1);
+      expect(scorer.getDocumentFrequency("hello")).toBe(0);
+      expect(scorer.getDocumentFrequency("goodbye")).toBe(1);
+    });
+    it("should handle empty content", () => {
+      scorer.indexDocument("c1", "");
+      expect(scorer.getDocumentCount()).toBe(0);
+    });
+  });
+
+  describe("indexDocumentsBatch", () => {
+    it("should batch-index", () => {
+      scorer.indexDocumentsBatch([
+        { chunkId: "c1", content: "typescript function" },
+        { chunkId: "c2", content: "python class" },
+      ]);
+      expect(scorer.getDocumentCount()).toBe(2);
+    });
+    it("should handle 1000 docs efficiently", () => {
+      const docs = Array.from({ length: 1000 }, (_, i) => ({
+        chunkId: `chunk-${i}`, content: `document ${i} content topic ${i % 10}`,
+      }));
+      const start = Date.now();
+      scorer.indexDocumentsBatch(docs);
+      expect(scorer.getDocumentCount()).toBe(1000);
+      expect(Date.now() - start).toBeLessThan(2000);
+    });
+  });
+
+  describe("removeDocument", () => {
+    it("should remove", () => {
+      scorer.indexDocument("c1", "hello world");
+      scorer.removeDocument("c1");
+      expect(scorer.getDocumentCount()).toBe(0);
+    });
+    it("should not fail on nonexistent", () => {
+      expect(() => scorer.removeDocument("x")).not.toThrow();
+    });
+  });
+
+  describe("search", () => {
+    it("should return empty for empty query", () => {
+      scorer.indexDocument("c1", "hello world");
+      expect(scorer.search("")).toEqual([]);
+    });
+    it("should return empty for no match", () => {
+      scorer.indexDocument("c1", "hello world");
+      expect(scorer.search("quantum")).toEqual([]);
+    });
+    it("should return empty for empty corpus", () => {
+      expect(scorer.search("hello")).toEqual([]);
+    });
+    it("should find matching documents", () => {
+      scorer.indexDocumentsBatch([
+        { chunkId: "c1", content: "typescript function for computing scores" },
+        { chunkId: "c2", content: "python class for data processing" },
+      ]);
+      const results = scorer.search("typescript function");
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]!.chunkId).toBe("c1");
+      expect(results[0]!.score).toBeGreaterThan(0);
+    });
+    it("should rank by term frequency", () => {
+      scorer.indexDocumentsBatch([
+        { chunkId: "c1", content: "scoring scoring scoring algorithm" },
+        { chunkId: "c2", content: "this uses scoring for ranking" },
+      ]);
+      const results = scorer.search("scoring");
+      expect(results).toHaveLength(2);
+      expect(results[0]!.chunkId).toBe("c1");
+      expect(results[0]!.score).toBeGreaterThan(results[1]!.score);
+    });
+    it("should respect limit", () => {
+      const docs = Array.from({ length: 20 }, (_, i) => ({
+        chunkId: `c${i}`, content: `search function variant ${i}`,
+      }));
+      scorer.indexDocumentsBatch(docs);
+      expect(scorer.search("search function", 5)).toHaveLength(5);
+    });
+    it("should filter by chunkIds", () => {
+      scorer.indexDocumentsBatch([
+        { chunkId: "c1", content: "typescript function" },
+        { chunkId: "c2", content: "typescript class" },
+        { chunkId: "c3", content: "typescript module" },
+      ]);
+      const filterSet = new Set(["c1", "c3"]);
+      const results = scorer.search("typescript", 10, filterSet);
+      expect(results.every((r) => filterSet.has(r.chunkId))).toBe(true);
+    });
+    it("should weight rare terms higher (IDF)", () => {
+      scorer.indexDocumentsBatch([
+        { chunkId: "c1", content: "common word rare unique" },
+        { chunkId: "c2", content: "common word another" },
+        { chunkId: "c3", content: "common word yet another" },
+      ]);
+      const results = scorer.search("rare");
+      expect(results).toHaveLength(1);
+      expect(results[0]!.chunkId).toBe("c1");
+    });
+    it("should handle duplicate query terms", () => {
+      scorer.indexDocument("c1", "test content for verification");
+      const r1 = scorer.search("test test test");
+      const r2 = scorer.search("test");
+      expect(r1[0]!.score).toBe(r2[0]!.score);
+    });
+  });
+
+  describe("determinism", () => {
+    it("same corpus + query = same scores across instances", () => {
+      const docs = [
+        { chunkId: "c1", content: "typescript function for BM25 scores" },
+        { chunkId: "c2", content: "python class for data processing" },
+        { chunkId: "c3", content: "rust struct with generics" },
+      ];
+      const query = "function data processing";
+      const db1 = new Database(":memory:");
+      const s1 = new BM25Scorer(db1);
+      s1.indexDocumentsBatch(docs);
+      const r1 = s1.search(query);
+      const db2 = new Database(":memory:");
+      const s2 = new BM25Scorer(db2);
+      s2.indexDocumentsBatch(docs);
+      const r2 = s2.search(query);
+      expect(r1.length).toBe(r2.length);
+      for (let i = 0; i < r1.length; i++) {
+        expect(r1[i]!.chunkId).toBe(r2[i]!.chunkId);
+        expect(r1[i]!.score).toBe(r2[i]!.score);
+      }
+      db1.close(); db2.close();
+    });
+
+    it("deterministic across 10 runs", () => {
+      const docs = [
+        { chunkId: "c1", content: "export class BM25Scorer implements Ranker" },
+        { chunkId: "c2", content: "export function tokenize text into terms" },
+      ];
+      const allRuns: Array<Array<{ chunkId: string; score: number }>> = [];
+      for (let run = 0; run < 10; run++) {
+        const runDb = new Database(":memory:");
+        const runScorer = new BM25Scorer(runDb);
+        runScorer.indexDocumentsBatch(docs);
+        allRuns.push(runScorer.search("BM25 scorer"));
+        runDb.close();
+      }
+      for (let run = 1; run < allRuns.length; run++) {
+        expect(allRuns[run]!.length).toBe(allRuns[0]!.length);
+        for (let i = 0; i < allRuns[0]!.length; i++) {
+          expect(allRuns[run]![i]!.chunkId).toBe(allRuns[0]![i]!.chunkId);
+          expect(allRuns[run]![i]!.score).toBe(allRuns[0]![i]!.score);
+        }
+      }
+    });
+  });
+
+  describe("BM25 parameters", () => {
+    it("should use custom k1 and b", () => {
+      scorer.indexDocumentsBatch([
+        { chunkId: "c1", content: "test test test document" },
+        { chunkId: "c2", content: "another document testing" },
+      ]);
+      const db2 = new Database(":memory:");
+      const s2 = new BM25Scorer(db2, { k1: 2.0, b: 0.5 });
+      s2.indexDocumentsBatch([
+        { chunkId: "c1", content: "test test test document" },
+        { chunkId: "c2", content: "another document testing" },
+      ]);
+      const r1 = scorer.search("test");
+      const r2 = s2.search("test");
+      expect(r1.length).toBe(r2.length);
+      expect(r1[0]!.score).not.toBe(r2[0]!.score);
+      db2.close();
+    });
+  });
+
+  describe("corpus statistics", () => {
+    it("should track doc count", () => {
+      expect(scorer.getDocumentCount()).toBe(0);
+      scorer.indexDocument("c1", "hello");
+      expect(scorer.getDocumentCount()).toBe(1);
+      scorer.removeDocument("c1");
+      expect(scorer.getDocumentCount()).toBe(0);
+    });
+    it("should compute avg doc length", () => {
+      scorer.indexDocumentsBatch([
+        { chunkId: "c1", content: "one two three" },
+        { chunkId: "c2", content: "four five six seven" },
+        { chunkId: "c3", content: "eight" },
+      ]);
+      expect(scorer.getAverageDocLength()).toBeCloseTo(2.667, 2);
+    });
+    it("should compute df correctly", () => {
+      scorer.indexDocumentsBatch([
+        { chunkId: "c1", content: "hello world" },
+        { chunkId: "c2", content: "hello universe" },
+        { chunkId: "c3", content: "goodbye world" },
+      ]);
+      expect(scorer.getDocumentFrequency("hello")).toBe(2);
+      expect(scorer.getDocumentFrequency("world")).toBe(2);
+      expect(scorer.getDocumentFrequency("universe")).toBe(1);
+      expect(scorer.getDocumentFrequency("nonexistent")).toBe(0);
+    });
+  });
+
+  describe("search latency", () => {
+    it("should search 10k chunks in under 100ms", () => {
+      const docs = Array.from({ length: 10000 }, (_, i) => ({
+        chunkId: `chunk-${i}`,
+        content: `export function handler${i}(req: Request): Response { return new Response("ok ${i % 100}") }`,
+      }));
+      scorer.indexDocumentsBatch(docs);
+      expect(scorer.getDocumentCount()).toBe(10000);
+      const start = performance.now();
+      const results = scorer.search("function handler request response", 10);
+      const elapsed = performance.now() - start;
+      expect(results.length).toBeGreaterThan(0);
+      expect(elapsed).toBeLessThan(100);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces `DeterministicVectorizer` (n-gram hash, cosine similarity 0.05-0.20) with `BM25Scorer` as the default code search ranker
- New SQLite-backed inverted index (`bm25_inverted_index` table) built during `codebase_ingest`
- Hybrid mode when Qdrant is available: BM25 * 0.6 + dense * 0.4 weighted scoring
- Search latency < 100ms for 10,000 chunks; fully deterministic (same input = same scores)

## Implementation
- `BM25Scorer` class with configurable k1=1.5, b=0.75 parameters
- IDF formula: `log(1 + (N - df + 0.5) / (df + 0.5))` (Lucene BM25 variant, always non-negative)
- `indexDocumentsBatch()` for efficient bulk indexing in SQLite transactions
- Wired into `CodeIndexer`, `IngestionService`, `PingMemServer`, and HTTP server
- `DeterministicVectorizer` retained for Qdrant vector generation (backward compatibility)

## Test plan
- [x] 26 unit tests covering tokenization, indexing, search, determinism, custom parameters, latency
- [x] Determinism tests: 10 consecutive runs produce identical scores
- [x] Performance test: search over 10,000 chunks completes in < 100ms
- [x] Existing tests pass with no regressions (1897 pass, 1 pre-existing fail)
- [ ] Integration test with live Qdrant for hybrid mode verification

Closes #28

Generated with [Claude Code](https://claude.com/claude-code)