### PR TITLE
feat: shell integration — hooks, daemon, auto-context tracking

### DIFF
--- a/src/cli/__tests__/daemon.test.ts
+++ b/src/cli/__tests__/daemon.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for daemon lifecycle management.
+ */
+
+import { describe, test, expect } from "bun:test";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import {
+  getDefaultDaemonConfig,
+  getDefaultSocketPath,
+  isDaemonRunning,
+} from "../daemon.js";
+
+describe("daemon config", () => {
+  test("getDefaultSocketPath returns path with UID", () => {
+    const socketPath = getDefaultSocketPath();
+    expect(socketPath).toContain("ping-mem-");
+    expect(socketPath).toContain(".sock");
+  });
+
+  test("getDefaultDaemonConfig returns valid config", () => {
+    const cfg = getDefaultDaemonConfig();
+    expect(cfg.socketPath).toContain("ping-mem-");
+    expect(cfg.pidFile).toContain(path.join(".ping-mem", "daemon.pid"));
+    expect(cfg.serverUrl).toBe("http://localhost:3000");
+  });
+
+  test("isDaemonRunning returns false when no PID file exists", () => {
+    const running = isDaemonRunning({
+      pidFile: path.join(os.tmpdir(), `ping-mem-test-nonexistent-${Date.now()}.pid`),
+      socketPath: "/tmp/nonexistent.sock",
+      serverUrl: "http://localhost:3000",
+    });
+    expect(running).toBe(false);
+  });
+
+  test("isDaemonRunning returns false for stale PID", () => {
+    const tmpPid = path.join(os.tmpdir(), `ping-mem-test-stale-${Date.now()}.pid`);
+    // Write a PID that definitely doesn't exist (very high number)
+    fs.writeFileSync(tmpPid, "999999999");
+    try {
+      const running = isDaemonRunning({
+        pidFile: tmpPid,
+        socketPath: "/tmp/nonexistent.sock",
+        serverUrl: "http://localhost:3000",
+      });
+      expect(running).toBe(false);
+    } finally {
+      try { fs.unlinkSync(tmpPid); } catch { /* ignore */ }
+    }
+  });
+
+  test("isDaemonRunning returns true for current process PID", () => {
+    const tmpPid = path.join(os.tmpdir(), `ping-mem-test-live-${Date.now()}.pid`);
+    fs.writeFileSync(tmpPid, String(process.pid));
+    try {
+      const running = isDaemonRunning({
+        pidFile: tmpPid,
+        socketPath: "/tmp/nonexistent.sock",
+        serverUrl: "http://localhost:3000",
+      });
+      expect(running).toBe(true);
+    } finally {
+      try { fs.unlinkSync(tmpPid); } catch { /* ignore */ }
+    }
+  });
+});

--- a/src/cli/__tests__/shell-hook.test.ts
+++ b/src/cli/__tests__/shell-hook.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for shell-hook command output.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+// We test by importing the module and checking the hook strings
+// The command itself just writes to stdout, so we test the content patterns
+
+describe("shell-hook command", () => {
+  test("zsh hook contains precmd and chpwd hooks", async () => {
+    // Import the module to get the exported command
+    const mod = await import("../commands/shell-hook.js");
+    const cmd = mod.default;
+    expect(cmd.meta?.name).toBe("shell-hook");
+  });
+
+  test("zsh hook output contains required elements", () => {
+    // Verify the hook patterns by checking known strings
+    const zshHook = [
+      "_ping_mem_sock=",
+      "_ping_mem_send()",
+      "nc -U",
+      "socat",
+      "add-zsh-hook precmd",
+      "add-zsh-hook chpwd",
+      "_ping_mem_precmd",
+      "_ping_mem_chpwd",
+    ];
+
+    // Import synchronously from the file content
+    const fs = require("node:fs");
+    const content = fs.readFileSync(
+      require("node:path").resolve(__dirname, "../commands/shell-hook.ts"),
+      "utf-8",
+    ) as string;
+
+    for (const pattern of zshHook) {
+      expect(content).toContain(pattern);
+    }
+  });
+
+  test("bash hook output contains required elements", () => {
+    const fs = require("node:fs");
+    const content = fs.readFileSync(
+      require("node:path").resolve(__dirname, "../commands/shell-hook.ts"),
+      "utf-8",
+    ) as string;
+
+    const bashPatterns = [
+      "PROMPT_COMMAND=",
+      "nc -U",
+      "socat",
+    ];
+
+    for (const pattern of bashPatterns) {
+      expect(content).toContain(pattern);
+    }
+  });
+
+  test("fish hook output contains required elements", () => {
+    const fs = require("node:fs");
+    const content = fs.readFileSync(
+      require("node:path").resolve(__dirname, "../commands/shell-hook.ts"),
+      "utf-8",
+    ) as string;
+
+    const fishPatterns = [
+      "fish_prompt",
+      "--on-variable PWD",
+      "nc -U",
+      "socat",
+    ];
+
+    for (const pattern of fishPatterns) {
+      expect(content).toContain(pattern);
+    }
+  });
+});

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -1,0 +1,107 @@
+/**
+ * Daemon management commands: start, stop, status
+ */
+
+import { defineCommand } from "citty";
+import { startDaemon, stopDaemon, isDaemonRunning, getDefaultDaemonConfig } from "../daemon.js";
+import { outputArgs, serverArgs } from "../shared.js";
+import { printOutput, resolveFormat } from "../output.js";
+
+const start = defineCommand({
+  meta: { name: "start", description: "Start the background daemon" },
+  args: {
+    ...outputArgs,
+    ...serverArgs,
+    foreground: {
+      type: "boolean",
+      description: "Run in foreground (don't detach)",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const format = resolveFormat(args);
+
+    if (isDaemonRunning()) {
+      printOutput({ status: "already-running", message: "Daemon is already running" }, format);
+      return;
+    }
+
+    const cfg = getDefaultDaemonConfig();
+    if (args.server) {
+      cfg.serverUrl = args.server;
+    }
+
+    if (args.foreground) {
+      printOutput({ status: "starting", message: "Starting daemon in foreground...", socketPath: cfg.socketPath }, format);
+      await startDaemon(cfg);
+      // startDaemon resolves when socket is listening; in foreground mode we keep the process alive
+      // The process stays alive because the net.Server keeps the event loop running
+      return;
+    }
+
+    // Background mode: spawn a detached child process
+    const { spawn } = await import("node:child_process");
+    const binPath = process.argv[1];
+    if (!binPath) {
+      console.error("Cannot determine executable path for background spawn");
+      process.exit(1);
+    }
+    const child = spawn(
+      process.argv[0] ?? "bun",
+      [binPath, "daemon", "start", "--foreground", ...(args.server ? ["--server", args.server] : [])],
+      {
+        detached: true,
+        stdio: "ignore",
+      },
+    );
+    child.unref();
+
+    // Wait briefly for the daemon to write its PID file
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    if (isDaemonRunning()) {
+      printOutput({ status: "started", message: "Daemon started", pid: child.pid, socketPath: cfg.socketPath }, format);
+    } else {
+      printOutput({ status: "error", message: "Daemon failed to start" }, format);
+      process.exit(1);
+    }
+  },
+});
+
+const stop = defineCommand({
+  meta: { name: "stop", description: "Stop the background daemon" },
+  args: {
+    ...outputArgs,
+  },
+  async run({ args }) {
+    const format = resolveFormat(args);
+    const stopped = await stopDaemon();
+    if (stopped) {
+      printOutput({ status: "stopped", message: "Daemon stopped" }, format);
+    } else {
+      printOutput({ status: "not-running", message: "Daemon is not running" }, format);
+    }
+  },
+});
+
+const status = defineCommand({
+  meta: { name: "status", description: "Check daemon status" },
+  args: {
+    ...outputArgs,
+  },
+  run({ args }) {
+    const format = resolveFormat(args);
+    const running = isDaemonRunning();
+    const cfg = getDefaultDaemonConfig();
+    printOutput({
+      status: running ? "running" : "stopped",
+      socketPath: cfg.socketPath,
+      pidFile: cfg.pidFile,
+    }, format);
+  },
+});
+
+export default defineCommand({
+  meta: { name: "daemon", description: "Background daemon management" },
+  subCommands: { start, stop, status },
+});

--- a/src/cli/commands/shell-hook.ts
+++ b/src/cli/commands/shell-hook.ts
@@ -1,0 +1,100 @@
+/**
+ * Shell hook generator command.
+ *
+ * Outputs shell integration code for zsh, bash, or fish.
+ * Usage: ping-mem shell-hook zsh
+ */
+
+import { defineCommand } from "citty";
+
+const ZSH_HOOK = `# ping-mem shell integration (zsh)
+# Add to ~/.zshrc: eval "$(ping-mem shell-hook zsh)"
+
+_ping_mem_sock="\${XDG_RUNTIME_DIR:-/tmp}/ping-mem-$(id -u).sock"
+
+_ping_mem_send() {
+  [[ -S "$_ping_mem_sock" ]] || return 0
+  if command -v nc &>/dev/null; then
+    printf '%s\\n' "$1" | nc -U "$_ping_mem_sock" 2>/dev/null &!
+  elif command -v socat &>/dev/null; then
+    printf '%s\\n' "$1" | socat - UNIX-CONNECT:"$_ping_mem_sock" 2>/dev/null &!
+  fi
+}
+
+_ping_mem_precmd() { _ping_mem_send "precmd:$PWD"; }
+_ping_mem_chpwd() { _ping_mem_send "chdir:$PWD"; }
+
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _ping_mem_precmd
+add-zsh-hook chpwd _ping_mem_chpwd
+`;
+
+const BASH_HOOK = `# ping-mem shell integration (bash)
+# Add to ~/.bashrc: eval "$(ping-mem shell-hook bash)"
+
+_ping_mem_sock="\${XDG_RUNTIME_DIR:-/tmp}/ping-mem-$(id -u).sock"
+
+_ping_mem_send() {
+  [[ -S "$_ping_mem_sock" ]] || return 0
+  if command -v nc &>/dev/null; then
+    printf '%s\\n' "$1" | nc -U "$_ping_mem_sock" 2>/dev/null &
+  elif command -v socat &>/dev/null; then
+    printf '%s\\n' "$1" | socat - UNIX-CONNECT:"$_ping_mem_sock" 2>/dev/null &
+  fi
+}
+
+PROMPT_COMMAND="_ping_mem_send \\"precmd:\\$PWD\\";\${PROMPT_COMMAND:+\$PROMPT_COMMAND}"
+
+_ping_mem_original_cd() { builtin cd "\$@" && _ping_mem_send "chdir:\$PWD"; }
+alias cd='_ping_mem_original_cd'
+`;
+
+const FISH_HOOK = `# ping-mem shell integration (fish)
+# Add to ~/.config/fish/config.fish: ping-mem shell-hook fish | source
+
+set -g _ping_mem_sock (test -n "$XDG_RUNTIME_DIR"; and echo "$XDG_RUNTIME_DIR"; or echo "/tmp")"/ping-mem-"(id -u)".sock"
+
+function _ping_mem_send
+  test -S "$_ping_mem_sock"; or return 0
+  if command -sq nc
+    printf '%s\\n' $argv[1] | nc -U "$_ping_mem_sock" 2>/dev/null &
+  else if command -sq socat
+    printf '%s\\n' $argv[1] | socat - UNIX-CONNECT:"$_ping_mem_sock" 2>/dev/null &
+  end
+end
+
+function _ping_mem_prompt --on-event fish_prompt
+  _ping_mem_send "precmd:$PWD"
+end
+
+function _ping_mem_chdir --on-variable PWD
+  _ping_mem_send "chdir:$PWD"
+end
+`;
+
+const SHELL_HOOKS: Record<string, string> = {
+  zsh: ZSH_HOOK,
+  bash: BASH_HOOK,
+  fish: FISH_HOOK,
+};
+
+export default defineCommand({
+  meta: { name: "shell-hook", description: "Generate shell integration code" },
+  args: {
+    shell: {
+      type: "positional",
+      description: "Shell type: zsh, bash, or fish",
+      required: true,
+    },
+  },
+  run({ args }) {
+    const shell = args.shell.toLowerCase();
+    const hook = SHELL_HOOKS[shell];
+    if (!hook) {
+      console.error(`Unsupported shell: ${shell}. Supported: zsh, bash, fish`);
+      process.exit(1);
+    }
+    // Output raw hook code — meant to be eval'd by the shell
+    process.stdout.write(hook);
+  },
+});

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -1,0 +1,242 @@
+/**
+ * Background daemon for ping-mem shell integration.
+ *
+ * Listens on a Unix domain socket, receives lightweight text messages
+ * from shell hooks, batches events, and forwards them to the REST API.
+ */
+
+import * as net from "node:net";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { createClient, type ClientOptions } from "./client.js";
+
+export interface DaemonConfig {
+  socketPath: string;
+  pidFile: string;
+  serverUrl: string;
+}
+
+export function getDefaultSocketPath(): string {
+  const runtimeDir = process.env.XDG_RUNTIME_DIR ?? "/tmp";
+  return path.join(runtimeDir, `ping-mem-${process.getuid?.() ?? 0}.sock`);
+}
+
+export function getDefaultDaemonConfig(): DaemonConfig {
+  const configDir = path.join(os.homedir(), ".ping-mem");
+  return {
+    socketPath: getDefaultSocketPath(),
+    pidFile: path.join(configDir, "daemon.pid"),
+    serverUrl: "http://localhost:3000",
+  };
+}
+
+/**
+ * Detect the git project root for a given directory.
+ * Returns null if not inside a git repo.
+ */
+function detectGitRoot(dir: string): string | null {
+  let current = dir;
+  const root = path.parse(current).root;
+  while (current !== root) {
+    if (fs.existsSync(path.join(current, ".git"))) {
+      return current;
+    }
+    current = path.dirname(current);
+  }
+  return null;
+}
+
+/**
+ * Detect the current git branch for a directory.
+ * Returns null if not in a git repo or branch cannot be determined.
+ */
+function detectGitBranch(gitRoot: string): string | null {
+  try {
+    const headPath = path.join(gitRoot, ".git", "HEAD");
+    const head = fs.readFileSync(headPath, "utf-8").trim();
+    if (head.startsWith("ref: refs/heads/")) {
+      return head.slice("ref: refs/heads/".length);
+    }
+    // Detached HEAD — return short hash
+    return head.slice(0, 8);
+  } catch {
+    return null;
+  }
+}
+
+/** Batch buffer for shell events before flushing to the REST API. */
+interface ShellEvent {
+  type: "precmd" | "chdir";
+  directory: string;
+  timestamp: string;
+  gitRoot: string | null;
+  gitBranch: string | null;
+}
+
+export async function startDaemon(config?: Partial<DaemonConfig>): Promise<void> {
+  const cfg: DaemonConfig = { ...getDefaultDaemonConfig(), ...config };
+
+  // Ensure config directory exists for PID file
+  const pidDir = path.dirname(cfg.pidFile);
+  fs.mkdirSync(pidDir, { recursive: true });
+
+  // Remove stale socket if it exists
+  if (fs.existsSync(cfg.socketPath)) {
+    try {
+      fs.unlinkSync(cfg.socketPath);
+    } catch {
+      // Ignore — may be cleaned up by OS
+    }
+  }
+
+  // Write PID file
+  fs.writeFileSync(cfg.pidFile, String(process.pid));
+
+  const client = createClient({ serverUrl: cfg.serverUrl });
+
+  // Event batching: accumulate events, flush every 2 seconds
+  let eventBatch: ShellEvent[] = [];
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function scheduleBatchFlush(): void {
+    if (flushTimer !== null) return;
+    flushTimer = setTimeout(() => {
+      flushTimer = null;
+      void flushBatch();
+    }, 2000);
+  }
+
+  async function flushBatch(): Promise<void> {
+    if (eventBatch.length === 0) return;
+    const batch = eventBatch;
+    eventBatch = [];
+
+    // Only send the latest event per directory (dedup)
+    const latest = new Map<string, ShellEvent>();
+    for (const evt of batch) {
+      latest.set(evt.directory, evt);
+    }
+
+    for (const evt of latest.values()) {
+      try {
+        await client.post("/api/v1/shell/event", evt as unknown as Record<string, unknown>);
+      } catch {
+        // Fire-and-forget — daemon must not crash on API errors
+      }
+    }
+  }
+
+  function handleMessage(raw: string): void {
+    const trimmed = raw.trim();
+    if (!trimmed) return;
+
+    const colonIdx = trimmed.indexOf(":");
+    if (colonIdx === -1) return;
+
+    const type = trimmed.slice(0, colonIdx);
+    const directory = trimmed.slice(colonIdx + 1);
+
+    if (type !== "precmd" && type !== "chdir") return;
+    if (!directory || !path.isAbsolute(directory)) return;
+
+    const gitRoot = detectGitRoot(directory);
+    const gitBranch = gitRoot ? detectGitBranch(gitRoot) : null;
+
+    eventBatch.push({
+      type: type as "precmd" | "chdir",
+      directory,
+      timestamp: new Date().toISOString(),
+      gitRoot,
+      gitBranch,
+    });
+    scheduleBatchFlush();
+  }
+
+  const server = net.createServer((socket) => {
+    let buffer = "";
+    socket.on("data", (data) => {
+      buffer += data.toString();
+      const lines = buffer.split("\n");
+      // Keep the last incomplete line in the buffer
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        handleMessage(line);
+      }
+    });
+    socket.on("end", () => {
+      if (buffer.trim()) {
+        handleMessage(buffer);
+      }
+    });
+    socket.on("error", () => {
+      // Ignore client errors — shell hooks disconnect immediately
+    });
+  });
+
+  function cleanup(): void {
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+    try { fs.unlinkSync(cfg.socketPath); } catch { /* ignore */ }
+    try { fs.unlinkSync(cfg.pidFile); } catch { /* ignore */ }
+    server.close();
+  }
+
+  process.on("SIGTERM", () => {
+    cleanup();
+    process.exit(0);
+  });
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(0);
+  });
+
+  return new Promise<void>((resolve, reject) => {
+    server.on("error", (err) => {
+      cleanup();
+      reject(err);
+    });
+    server.listen(cfg.socketPath, () => {
+      // Make socket writable by the user only
+      try { fs.chmodSync(cfg.socketPath, 0o600); } catch { /* ignore */ }
+      resolve();
+    });
+  });
+}
+
+export async function stopDaemon(config?: Partial<DaemonConfig>): Promise<boolean> {
+  const cfg: DaemonConfig = { ...getDefaultDaemonConfig(), ...config };
+
+  try {
+    const pidStr = fs.readFileSync(cfg.pidFile, "utf-8").trim();
+    const pid = parseInt(pidStr, 10);
+    if (isNaN(pid)) {
+      return false;
+    }
+    process.kill(pid, "SIGTERM");
+    // Clean up PID file and socket
+    try { fs.unlinkSync(cfg.pidFile); } catch { /* ignore */ }
+    try { fs.unlinkSync(cfg.socketPath); } catch { /* ignore */ }
+    return true;
+  } catch {
+    // PID file doesn't exist or process already gone
+    return false;
+  }
+}
+
+export function isDaemonRunning(config?: Partial<DaemonConfig>): boolean {
+  const cfg: DaemonConfig = { ...getDefaultDaemonConfig(), ...config };
+
+  try {
+    const pidStr = fs.readFileSync(cfg.pidFile, "utf-8").trim();
+    const pid = parseInt(pidStr, 10);
+    if (isNaN(pid)) return false;
+    // signal 0 checks if process exists without sending a signal
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,8 @@ import toolsCmd from "./commands/tools.js";
 import serverCmd from "./commands/server.js";
 import authCmd from "./commands/auth.js";
 import configCmd from "./commands/config.js";
+import shellHookCmd from "./commands/shell-hook.js";
+import daemonCmd from "./commands/daemon.js";
 
 function readVersion(): string {
   try {
@@ -56,6 +58,8 @@ const main = defineCommand({
     server: serverCmd,
     auth: authCmd,
     config: configCmd,
+    "shell-hook": shellHookCmd,
+    daemon: daemonCmd,
   },
 });
 

--- a/src/http/rest-server.ts
+++ b/src/http/rest-server.ts
@@ -90,6 +90,7 @@ import { diagnosticsIngestBaseSchema } from "../validation/diagnostics-schemas.j
 import type { QdrantClientWrapper } from "../search/QdrantClient.js";
 import { IngestionQueue } from "../ingest/IngestionQueue.js";
 import { registerOpenAPIRoute } from "./routes/openapi.js";
+import { registerShellRoutes } from "./routes/shell.js";
 
 /** Maximum SARIF payload size in bytes (5 MB) */
 const MAX_SARIF_BYTES = 5 * 1024 * 1024;
@@ -2971,6 +2972,14 @@ export class RESTPingMemServer {
       } catch (error) {
         return this.handleError(c, error);
       }
+    });
+
+    // ============================================================================
+    // Shell Event Endpoint
+    // ============================================================================
+    registerShellRoutes(this.app, {
+      eventStore: this.eventStore,
+      getCurrentSessionId: () => this.currentSessionId,
     });
 
     // ============================================================================

--- a/src/http/routes/__tests__/shell.test.ts
+++ b/src/http/routes/__tests__/shell.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for shell event REST routes.
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import { Hono } from "hono";
+import { registerShellRoutes } from "../shell.js";
+import { EventStore } from "../../../storage/EventStore.js";
+import { SessionManager } from "../../../session/SessionManager.js";
+import type { AppEnv } from "../../rest-server.js";
+
+describe("shell routes", () => {
+  let app: Hono<AppEnv>;
+  let eventStore: EventStore;
+  let sessionId: string;
+
+  beforeEach(async () => {
+    eventStore = new EventStore({ dbPath: ":memory:" });
+    const sessionManager = new SessionManager({ eventStore });
+    const session = await sessionManager.startSession({ name: "test-shell" });
+    sessionId = session.id;
+
+    app = new Hono<AppEnv>();
+    registerShellRoutes(app, {
+      eventStore,
+      getCurrentSessionId: () => sessionId,
+    });
+  });
+
+  test("POST /api/v1/shell/event — accepts precmd event", async () => {
+    const res = await app.request("/api/v1/shell/event", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "precmd",
+        directory: "/Users/test/project",
+        timestamp: "2026-03-17T10:00:00.000Z",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { data: { success: boolean; type: string; directory: string } };
+    expect(body.data.success).toBe(true);
+    expect(body.data.type).toBe("precmd");
+    expect(body.data.directory).toBe("/Users/test/project");
+  });
+
+  test("POST /api/v1/shell/event — accepts chdir event with git info", async () => {
+    const res = await app.request("/api/v1/shell/event", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "chdir",
+        directory: "/Users/test/project",
+        gitRoot: "/Users/test/project",
+        gitBranch: "main",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { data: { success: boolean; gitRoot: string; gitBranch: string } };
+    expect(body.data.success).toBe(true);
+    expect(body.data.gitRoot).toBe("/Users/test/project");
+    expect(body.data.gitBranch).toBe("main");
+  });
+
+  test("POST /api/v1/shell/event — rejects invalid type", async () => {
+    const res = await app.request("/api/v1/shell/event", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "invalid",
+        directory: "/tmp",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  test("POST /api/v1/shell/event — rejects missing directory", async () => {
+    const res = await app.request("/api/v1/shell/event", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "precmd",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  test("POST /api/v1/shell/event — rejects invalid JSON", async () => {
+    const res = await app.request("/api/v1/shell/event", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  test("POST /api/v1/shell/event — returns 400 when no session", async () => {
+    const noSessionApp = new Hono<AppEnv>();
+    registerShellRoutes(noSessionApp, {
+      eventStore,
+      getCurrentSessionId: () => null,
+    });
+
+    const res = await noSessionApp.request("/api/v1/shell/event", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "precmd",
+        directory: "/tmp",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { message: string };
+    expect(body.message).toContain("No active session");
+  });
+
+  test("GET /api/v1/shell/latest — returns latest shell directory", async () => {
+    // First post an event
+    await app.request("/api/v1/shell/event", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "chdir",
+        directory: "/Users/test/project-a",
+      }),
+    });
+
+    // Then query latest
+    const res = await app.request("/api/v1/shell/latest");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { data: { directory: string } };
+    expect(body.data.directory).toBe("/Users/test/project-a");
+  });
+
+  test("GET /api/v1/shell/latest — returns null when no events", async () => {
+    const res = await app.request("/api/v1/shell/latest");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { data: { directory: string | null } };
+    expect(body.data.directory).toBeNull();
+  });
+});

--- a/src/http/routes/shell.ts
+++ b/src/http/routes/shell.ts
@@ -1,0 +1,167 @@
+/**
+ * Shell event ingestion route.
+ *
+ * POST /api/v1/shell/event — accepts events from the shell daemon
+ * and stores them as context memories.
+ */
+
+import type { Hono } from "hono";
+import type { AppEnv } from "../rest-server.js";
+import type { RESTErrorResponse, RESTSuccessResponse } from "../types.js";
+import type { EventStore } from "../../storage/EventStore.js";
+import type { SessionId } from "../../types/index.js";
+
+export interface ShellRoutesDeps {
+  eventStore: EventStore;
+  getCurrentSessionId: () => SessionId | null;
+}
+
+interface ShellEventBody {
+  type: "precmd" | "chdir";
+  directory: string;
+  timestamp?: string;
+  gitRoot?: string | null;
+  gitBranch?: string | null;
+}
+
+export function registerShellRoutes(app: Hono<AppEnv>, deps: ShellRoutesDeps): void {
+  app.post("/api/v1/shell/event", async (c) => {
+    try {
+      let body: ShellEventBody;
+      try {
+        body = await c.req.json<ShellEventBody>();
+      } catch {
+        return c.json<RESTErrorResponse>(
+          { error: "Bad Request", message: "Invalid JSON" },
+          400,
+        );
+      }
+
+      // Validate required fields
+      if (!body.type || !["precmd", "chdir"].includes(body.type)) {
+        return c.json<RESTErrorResponse>(
+          { error: "Bad Request", message: "type must be 'precmd' or 'chdir'" },
+          400,
+        );
+      }
+      if (!body.directory || typeof body.directory !== "string") {
+        return c.json<RESTErrorResponse>(
+          { error: "Bad Request", message: "directory is required" },
+          400,
+        );
+      }
+
+      const sessionId: string | null =
+        c.req.header("x-session-id") ?? deps.getCurrentSessionId();
+
+      if (!sessionId) {
+        return c.json<RESTErrorResponse>(
+          { error: "Bad Request", message: "No active session. Start a session first." },
+          400,
+        );
+      }
+
+      const timestamp = body.timestamp ?? new Date().toISOString();
+
+      // Store as a CONTEXT_SAVED event with shell-specific metadata
+      const payload = {
+        key: "shell:latest-dir",
+        value: body.directory,
+        category: "note" as const,
+        tags: ["shell", "auto-context"],
+      };
+
+      const metadata: Record<string, unknown> = {
+        shellEventType: body.type,
+        directory: body.directory,
+        timestamp,
+      };
+
+      if (body.gitRoot) {
+        metadata.gitRoot = body.gitRoot;
+      }
+      if (body.gitBranch) {
+        metadata.gitBranch = body.gitBranch;
+      }
+
+      const event = await deps.eventStore.createEvent(
+        sessionId,
+        "MEMORY_SAVED",
+        payload,
+        metadata,
+      );
+
+      return c.json<RESTSuccessResponse<Record<string, unknown>>>({
+        data: {
+          success: true,
+          eventId: event.eventId,
+          type: body.type,
+          directory: body.directory,
+          timestamp,
+          gitRoot: body.gitRoot ?? null,
+          gitBranch: body.gitBranch ?? null,
+        },
+      });
+    } catch (error) {
+      return c.json<RESTErrorResponse>(
+        {
+          error: "Internal Server Error",
+          message: error instanceof Error ? error.message : "Unknown",
+        },
+        500,
+      );
+    }
+  });
+
+  // GET /api/v1/shell/latest — retrieve the latest shell directory
+  app.get("/api/v1/shell/latest", async (c) => {
+    try {
+      const sessionId: string | null =
+        c.req.query("sessionId") ?? c.req.header("x-session-id") ?? deps.getCurrentSessionId();
+
+      if (!sessionId) {
+        return c.json<RESTErrorResponse>(
+          { error: "Bad Request", message: "No active session" },
+          400,
+        );
+      }
+
+      const events = await deps.eventStore.getBySession(sessionId);
+      const shellEvents = events
+        .filter(
+          (e) =>
+            e.eventType === "MEMORY_SAVED" &&
+            (e.payload as Record<string, unknown>)?.key === "shell:latest-dir",
+        )
+        .slice(-1);
+
+      if (shellEvents.length === 0) {
+        return c.json<RESTSuccessResponse<Record<string, unknown>>>({
+          data: { directory: null, message: "No shell events recorded" },
+        });
+      }
+
+      const latest = shellEvents[0];
+      const latestPayload = latest?.payload as Record<string, unknown> | undefined;
+      const latestMeta = latest?.metadata as Record<string, unknown> | undefined;
+
+      return c.json<RESTSuccessResponse<Record<string, unknown>>>({
+        data: {
+          directory: latestPayload?.value ?? null,
+          type: latestMeta?.shellEventType ?? null,
+          gitRoot: latestMeta?.gitRoot ?? null,
+          gitBranch: latestMeta?.gitBranch ?? null,
+          timestamp: latestMeta?.timestamp ?? latest?.timestamp?.toISOString() ?? null,
+        },
+      });
+    } catch (error) {
+      return c.json<RESTErrorResponse>(
+        {
+          error: "Internal Server Error",
+          message: error instanceof Error ? error.message : "Unknown",
+        },
+        500,
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Summary
Phase 3 of the CLI/REST plan — ambient context tracking from the shell.

- `ping-mem shell-hook zsh/bash/fish` — generates shell integration code with nc/socat auto-detection
- `ping-mem daemon start/stop/status` — background Unix socket daemon
- `POST /api/v1/shell/event` + `GET /api/v1/shell/latest` — REST endpoints for shell events
- Auto-context: directory changes, git branch/root detection, session tracking

## Files (9 new, 923 lines)
- `src/cli/commands/shell-hook.ts` — shell hook generator (zsh/bash/fish)
- `src/cli/commands/daemon.ts` — daemon CLI commands
- `src/cli/daemon.ts` — daemon core (Unix socket, event batching, REST forwarding)
- `src/http/routes/shell.ts` — REST endpoints for shell events
- 3 test files with 17 tests

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] 17 new tests pass (hook generation, daemon config, REST endpoints)
- [x] No regressions

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added daemon management CLI commands: `start` (foreground/background modes), `stop`, and `status` for background process control.
  * Added `shell-hook` CLI command to generate shell integration code for zsh, bash, and fish.
  * Added shell event tracking API endpoints: POST `/api/v1/shell/event` accepts shell events and GET `/api/v1/shell/latest` retrieves the latest directory.

* **Tests**
  * Added comprehensive test coverage for daemon lifecycle, shell-hook output, and shell event API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->