### PR TITLE
feat: TypeScript SDK for ping-mem REST API

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     "diagnostics:tsc-sarif": "bun run src/diagnostics/tsc-sarif.ts",
     "diagnostics:eslint-sarif": "bun run src/diagnostics/eslint-sarif.ts",
     "diagnostics:prettier-sarif": "bun run src/diagnostics/prettier-sarif.ts",
-    "diagnostics:collect": "bun run src/cli.ts collect"
+    "diagnostics:collect": "bun run src/cli.ts collect",
+    "sdk:extract-openapi": "bun run scripts/extract-openapi.ts",
+    "sdk:build": "cd sdk/typescript && bun run build"
   },
   "keywords": [
     "ai",

--- a/scripts/extract-openapi.ts
+++ b/scripts/extract-openapi.ts
@@ -1,0 +1,16 @@
+/**
+ * Extract OpenAPI spec from the ping-mem REST server and write to sdk/openapi.json.
+ *
+ * Usage: bun run scripts/extract-openapi.ts
+ */
+import { generateOpenAPISpec } from "../src/http/routes/openapi.js";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+
+const outPath = resolve(import.meta.dirname ?? ".", "../sdk/openapi.json");
+mkdirSync(dirname(outPath), { recursive: true });
+
+const spec = generateOpenAPISpec();
+writeFileSync(outPath, JSON.stringify(spec, null, 2) + "\n", "utf-8");
+
+console.log(`OpenAPI spec written to ${outPath}`);

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@ping-gadgets/ping-mem-sdk",
+  "version": "2.0.0",
+  "description": "TypeScript SDK for ping-mem REST API",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "ping-mem",
+    "sdk",
+    "ai",
+    "memory",
+    "agents"
+  ],
+  "license": "MIT",
+  "dependencies": {},
+  "peerDependencies": {}
+}

--- a/sdk/typescript/src/__tests__/sdk.test.ts
+++ b/sdk/typescript/src/__tests__/sdk.test.ts
@@ -1,0 +1,410 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { PingMemSDK, PingMemError, createClient } from "../client.js";
+
+describe("PingMemSDK", () => {
+  // ── Constructor ──────────────────────────────────────
+
+  test("strips trailing slashes from baseUrl", () => {
+    const sdk = new PingMemSDK({ baseUrl: "http://localhost:3000///" });
+    // Verify by making a request and checking the URL
+    expect(sdk).toBeDefined();
+  });
+
+  test("createClient returns a PingMemSDK instance", () => {
+    const sdk = createClient({ baseUrl: "http://localhost:3000" });
+    expect(sdk).toBeInstanceOf(PingMemSDK);
+  });
+
+  // ── Request building ─────────────────────────────────
+
+  describe("request building", () => {
+    let fetchMock: ReturnType<typeof mock>;
+
+    beforeEach(() => {
+      fetchMock = mock(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ ok: true }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+      );
+      globalThis.fetch = fetchMock;
+    });
+
+    test("sends correct headers without API key", async () => {
+      const sdk = new PingMemSDK({ baseUrl: "http://localhost:3000" });
+      await sdk.health();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBe("application/json");
+      expect(headers["Authorization"]).toBeUndefined();
+    });
+
+    test("sends Authorization header with API key", async () => {
+      const sdk = new PingMemSDK({
+        baseUrl: "http://localhost:3000",
+        apiKey: "secret-key",
+      });
+      await sdk.health();
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe("Bearer secret-key");
+    });
+
+    test("sends custom headers", async () => {
+      const sdk = new PingMemSDK({
+        baseUrl: "http://localhost:3000",
+        headers: { "X-Custom": "value" },
+      });
+      await sdk.health();
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["X-Custom"]).toBe("value");
+    });
+
+    test("GET request has no body", async () => {
+      const sdk = new PingMemSDK({ baseUrl: "http://localhost:3000" });
+      await sdk.health();
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(init.body).toBeNull();
+    });
+
+    test("POST request serializes body as JSON", async () => {
+      const sdk = new PingMemSDK({ baseUrl: "http://localhost:3000" });
+      await sdk.sessionStart({ name: "test-session" });
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe("POST");
+      const parsed = JSON.parse(init.body as string) as Record<string, unknown>;
+      expect(parsed).toEqual({ name: "test-session" });
+    });
+
+    test("GET with query params appends to URL", async () => {
+      const sdk = new PingMemSDK({ baseUrl: "http://localhost:3000" });
+      await sdk.codebaseSearch({ query: "auth", limit: 5 });
+
+      const [url] = fetchMock.mock.calls[0] as [string];
+      const parsed = new URL(url);
+      expect(parsed.searchParams.get("query")).toBe("auth");
+      expect(parsed.searchParams.get("limit")).toBe("5");
+    });
+
+    test("undefined query params are omitted", async () => {
+      const sdk = new PingMemSDK({ baseUrl: "http://localhost:3000" });
+      await sdk.codebaseSearch({ query: "auth" });
+
+      const [url] = fetchMock.mock.calls[0] as [string];
+      const parsed = new URL(url);
+      expect(parsed.searchParams.get("query")).toBe("auth");
+      expect(parsed.searchParams.has("limit")).toBe(false);
+      expect(parsed.searchParams.has("projectId")).toBe(false);
+    });
+
+    test("path params are URL-encoded", async () => {
+      const sdk = new PingMemSDK({ baseUrl: "http://localhost:3000" });
+      await sdk.contextGet("key with spaces/special");
+
+      const [url] = fetchMock.mock.calls[0] as [string];
+      expect(url).toContain("key%20with%20spaces%2Fspecial");
+    });
+  });
+
+  // ── Error handling ───────────────────────────────────
+
+  describe("error handling", () => {
+    test("throws PingMemError on non-2xx response", async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ error: "not_found", message: "Key not found" }),
+            { status: 404, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+      );
+
+      const sdk = new PingMemSDK({ baseUrl: "http://localhost:3000" });
+
+      try {
+        await sdk.contextGet("missing-key");
+        expect(true).toBe(false); // should not reach
+      } catch (e) {
+        expect(e).toBeInstanceOf(PingMemError);
+        const err = e as PingMemError;
+        expect(err.status).toBe(404);
+        expect(err.message).toBe("Key not found");
+        expect(err.body).toEqual({
+          error: "not_found",
+          message: "Key not found",
+        });
+      }
+    });
+
+    test("falls back to statusText when response has no message field", async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ something: "else" }), {
+            status: 500,
+            statusText: "Internal Server Error",
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+      );
+
+      const sdk = new PingMemSDK({ baseUrl: "http://localhost:3000" });
+
+      try {
+        await sdk.health();
+        expect(true).toBe(false);
+      } catch (e) {
+        const err = e as PingMemError;
+        expect(err.status).toBe(500);
+        expect(err.message).toBe("Internal Server Error");
+      }
+    });
+  });
+
+  // ── Endpoint coverage ────────────────────────────────
+
+  describe("endpoint coverage", () => {
+    let fetchMock: ReturnType<typeof mock>;
+    let sdk: PingMemSDK;
+
+    beforeEach(() => {
+      fetchMock = mock(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ ok: true }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+      );
+      globalThis.fetch = fetchMock;
+      sdk = new PingMemSDK({ baseUrl: "http://localhost:3000" });
+    });
+
+    const assertCall = (
+      method: string,
+      pathIncludes: string,
+    ): void => {
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe(method);
+      expect(url).toContain(pathIncludes);
+    };
+
+    test("sessionStart", async () => {
+      await sdk.sessionStart({ name: "s" });
+      assertCall("POST", "/api/v1/session/start");
+    });
+
+    test("sessionEnd", async () => {
+      await sdk.sessionEnd({ sessionId: "abc" });
+      assertCall("POST", "/api/v1/session/end");
+    });
+
+    test("sessionList", async () => {
+      await sdk.sessionList(10);
+      assertCall("GET", "/api/v1/session/list");
+    });
+
+    test("contextSave", async () => {
+      await sdk.contextSave({ key: "k", value: "v" });
+      assertCall("POST", "/api/v1/context");
+    });
+
+    test("contextGet", async () => {
+      await sdk.contextGet("mykey");
+      assertCall("GET", "/api/v1/context/mykey");
+    });
+
+    test("contextSearch", async () => {
+      await sdk.contextSearch({ query: "q" });
+      assertCall("GET", "/api/v1/search");
+    });
+
+    test("contextDelete", async () => {
+      await sdk.contextDelete("mykey");
+      assertCall("DELETE", "/api/v1/context/mykey");
+    });
+
+    test("contextCheckpoint", async () => {
+      await sdk.contextCheckpoint("cp1");
+      assertCall("POST", "/api/v1/checkpoint");
+    });
+
+    test("contextStatus", async () => {
+      await sdk.contextStatus();
+      assertCall("GET", "/api/v1/status");
+    });
+
+    test("codebaseIngest", async () => {
+      await sdk.codebaseIngest({ projectDir: "/p" });
+      assertCall("POST", "/api/v1/codebase/ingest");
+    });
+
+    test("codebaseVerify", async () => {
+      await sdk.codebaseVerify("/p");
+      assertCall("POST", "/api/v1/codebase/verify");
+    });
+
+    test("codebaseSearch", async () => {
+      await sdk.codebaseSearch({ query: "q" });
+      assertCall("GET", "/api/v1/codebase/search");
+    });
+
+    test("codebaseTimeline", async () => {
+      await sdk.codebaseTimeline({ limit: 5 });
+      assertCall("GET", "/api/v1/codebase/timeline");
+    });
+
+    test("codebaseProjects", async () => {
+      await sdk.codebaseProjects();
+      assertCall("GET", "/api/v1/codebase/projects");
+    });
+
+    test("codebaseProjectDelete", async () => {
+      await sdk.codebaseProjectDelete("proj-id");
+      assertCall("DELETE", "/api/v1/codebase/projects/proj-id");
+    });
+
+    test("knowledgeSearch", async () => {
+      await sdk.knowledgeSearch({ query: "q" });
+      assertCall("POST", "/api/v1/knowledge/search");
+    });
+
+    test("knowledgeIngest", async () => {
+      await sdk.knowledgeIngest({
+        projectId: "p",
+        title: "t",
+        solution: "s",
+      });
+      assertCall("POST", "/api/v1/knowledge/ingest");
+    });
+
+    test("diagnosticsIngest", async () => {
+      await sdk.diagnosticsIngest({
+        projectId: "p",
+        treeHash: "h",
+        toolName: "tsc",
+        toolVersion: "5.0",
+        configHash: "c",
+        sarif: {},
+      });
+      assertCall("POST", "/api/v1/diagnostics/ingest");
+    });
+
+    test("diagnosticsLatest", async () => {
+      await sdk.diagnosticsLatest({ projectId: "p" });
+      assertCall("GET", "/api/v1/diagnostics/latest");
+    });
+
+    test("diagnosticsList", async () => {
+      await sdk.diagnosticsList("a1");
+      assertCall("GET", "/api/v1/diagnostics/findings/a1");
+    });
+
+    test("diagnosticsDiff", async () => {
+      await sdk.diagnosticsDiff({ analysisIdA: "a", analysisIdB: "b" });
+      assertCall("POST", "/api/v1/diagnostics/diff");
+    });
+
+    test("diagnosticsSummary", async () => {
+      await sdk.diagnosticsSummary("a1");
+      assertCall("GET", "/api/v1/diagnostics/summary/a1");
+    });
+
+    test("diagnosticsCompare", async () => {
+      await sdk.diagnosticsCompare({
+        projectId: "p",
+        treeHash: "h",
+        toolNames: "tsc,eslint",
+      });
+      assertCall("GET", "/api/v1/diagnostics/compare");
+    });
+
+    test("diagnosticsBySymbol", async () => {
+      await sdk.diagnosticsBySymbol({ analysisId: "a1" });
+      assertCall("GET", "/api/v1/diagnostics/by-symbol");
+    });
+
+    test("diagnosticsSummarize", async () => {
+      await sdk.diagnosticsSummarize("a1", { useLLM: true });
+      assertCall("POST", "/api/v1/diagnostics/summarize/a1");
+    });
+
+    test("agentRegister", async () => {
+      await sdk.agentRegister({ agentId: "ag1", role: "worker" });
+      assertCall("POST", "/api/v1/agents/register");
+    });
+
+    test("agentQuotas", async () => {
+      await sdk.agentQuotas("ag1");
+      assertCall("GET", "/api/v1/agents/quotas");
+    });
+
+    test("agentDeregister", async () => {
+      await sdk.agentDeregister("ag1");
+      assertCall("DELETE", "/api/v1/agents/ag1");
+    });
+
+    test("memoryStats", async () => {
+      await sdk.memoryStats();
+      assertCall("GET", "/api/v1/memory/stats");
+    });
+
+    test("memoryConsolidate", async () => {
+      await sdk.memoryConsolidate({ maxItems: 50 });
+      assertCall("POST", "/api/v1/memory/consolidate");
+    });
+
+    test("worklogRecord", async () => {
+      await sdk.worklogRecord({ kind: "diagnostics", title: "tsc" });
+      assertCall("POST", "/api/v1/worklog");
+    });
+
+    test("worklogList", async () => {
+      await sdk.worklogList(20);
+      assertCall("GET", "/api/v1/worklog");
+    });
+
+    test("causalCauses", async () => {
+      await sdk.causalCauses({ entity: "e1" });
+      assertCall("GET", "/api/v1/causal/causes");
+    });
+
+    test("causalEffects", async () => {
+      await sdk.causalEffects({ entity: "e1" });
+      assertCall("GET", "/api/v1/causal/effects");
+    });
+
+    test("causalChain", async () => {
+      await sdk.causalChain({ from: "a", to: "b" });
+      assertCall("GET", "/api/v1/causal/chain");
+    });
+
+    test("causalDiscover", async () => {
+      await sdk.causalDiscover({ projectId: "p" });
+      assertCall("POST", "/api/v1/causal/discover");
+    });
+
+    test("toolsList", async () => {
+      await sdk.toolsList();
+      assertCall("GET", "/api/v1/tools");
+    });
+
+    test("toolsGet", async () => {
+      await sdk.toolsGet("context_save");
+      assertCall("GET", "/api/v1/tools/context_save");
+    });
+
+    test("toolsInvoke", async () => {
+      await sdk.toolsInvoke("context_save", { key: "k", value: "v" });
+      assertCall("POST", "/api/v1/tools/context_save/invoke");
+    });
+  });
+});

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,0 +1,466 @@
+import type {
+  PingMemSDKConfig,
+  SessionStartInput,
+  SessionEndInput,
+  ContextSaveInput,
+  ContextSearchParams,
+  CodebaseIngestInput,
+  CodebaseSearchParams,
+  CodebaseTimelineParams,
+  KnowledgeIngestInput,
+  KnowledgeSearchInput,
+  DiagnosticsLatestParams,
+  DiagnosticsDiffInput,
+  DiagnosticsIngestInput,
+  DiagnosticsCompareParams,
+  DiagnosticsBySymbolParams,
+  AgentRegisterInput,
+  WorklogRecordInput,
+  MemoryConsolidateInput,
+  CausalSearchParams,
+  CausalChainParams,
+  CausalDiscoverInput,
+} from "./types.js";
+
+/**
+ * Thin TypeScript client for the ping-mem REST API.
+ *
+ * Uses only the built-in `fetch` API — zero runtime dependencies.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from "@ping-gadgets/ping-mem-sdk";
+ *
+ * const client = createClient({ baseUrl: "http://localhost:3000" });
+ * const health = await client.health();
+ * ```
+ */
+export class PingMemSDK {
+  private readonly baseUrl: string;
+  private readonly apiKey: string | undefined;
+  private readonly customHeaders: Record<string, string>;
+
+  constructor(config: PingMemSDKConfig) {
+    this.baseUrl = config.baseUrl.replace(/\/+$/, "");
+    this.apiKey = config.apiKey;
+    this.customHeaders = config.headers ?? {};
+  }
+
+  // ── Internal helpers ─────────────────────────────────
+
+  private headers(): Record<string, string> {
+    const h: Record<string, string> = {
+      "Content-Type": "application/json",
+      ...this.customHeaders,
+    };
+    if (this.apiKey) {
+      h["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+    return h;
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    params?: Record<string, string | undefined>,
+  ): Promise<T> {
+    const url = new URL(path, this.baseUrl);
+    if (params) {
+      for (const [k, v] of Object.entries(params)) {
+        if (v !== undefined && v !== "") {
+          url.searchParams.set(k, v);
+        }
+      }
+    }
+    const res = await fetch(url.toString(), {
+      method,
+      headers: this.headers(),
+      body: body !== undefined ? JSON.stringify(body) : null,
+    });
+    if (res.status === 204) {
+      return undefined as T;
+    }
+    const data: unknown = await res.json();
+    if (!res.ok) {
+      const msg =
+        typeof data === "object" && data !== null && "message" in data
+          ? (data as Record<string, unknown>)["message"]
+          : res.statusText;
+      throw new PingMemError(res.status, String(msg), data);
+    }
+    return data as T;
+  }
+
+  private toStr(v: number | undefined): string | undefined {
+    return v !== undefined ? String(v) : undefined;
+  }
+
+  // ── Health ───────────────────────────────────────────
+
+  /** Health check — always 200 if server is running. */
+  async health(): Promise<unknown> {
+    return this.request("GET", "/health");
+  }
+
+  // ── Session ──────────────────────────────────────────
+
+  /** Start a new session. */
+  async sessionStart(input: SessionStartInput): Promise<unknown> {
+    return this.request("POST", "/api/v1/session/start", input);
+  }
+
+  /** End an active session. */
+  async sessionEnd(input: SessionEndInput): Promise<unknown> {
+    return this.request("POST", "/api/v1/session/end", input);
+  }
+
+  /** List recent sessions. */
+  async sessionList(limit?: number): Promise<unknown> {
+    return this.request("GET", "/api/v1/session/list", undefined, {
+      limit: this.toStr(limit),
+    });
+  }
+
+  // ── Context ──────────────────────────────────────────
+
+  /** Save a memory entry. */
+  async contextSave(input: ContextSaveInput): Promise<unknown> {
+    return this.request("POST", "/api/v1/context", input);
+  }
+
+  /** Get a memory entry by key. */
+  async contextGet(key: string): Promise<unknown> {
+    return this.request("GET", `/api/v1/context/${encodeURIComponent(key)}`);
+  }
+
+  /** Search memories by query. */
+  async contextSearch(params: ContextSearchParams): Promise<unknown> {
+    return this.request("GET", "/api/v1/search", undefined, {
+      query: params.query,
+      limit: this.toStr(params.limit),
+      category: params.category,
+    });
+  }
+
+  /** Delete a memory entry by key. */
+  async contextDelete(key: string): Promise<unknown> {
+    return this.request(
+      "DELETE",
+      `/api/v1/context/${encodeURIComponent(key)}`,
+    );
+  }
+
+  /** Create a named checkpoint. */
+  async contextCheckpoint(name: string): Promise<unknown> {
+    return this.request("POST", "/api/v1/checkpoint", { name });
+  }
+
+  /** Get session and server status. */
+  async contextStatus(): Promise<unknown> {
+    return this.request("GET", "/api/v1/status");
+  }
+
+  // ── Graph ────────────────────────────────────────────
+
+  /** Query entity relationships. */
+  async graphRelationships(params?: Record<string, string>): Promise<unknown> {
+    return this.request(
+      "GET",
+      "/api/v1/graph/relationships",
+      undefined,
+      params,
+    );
+  }
+
+  /** Hybrid semantic + graph search. */
+  async graphHybridSearch(body: unknown): Promise<unknown> {
+    return this.request("POST", "/api/v1/graph/hybrid-search", body);
+  }
+
+  /** Get lineage for an entity. */
+  async graphLineage(entity: string): Promise<unknown> {
+    return this.request(
+      "GET",
+      `/api/v1/graph/lineage/${encodeURIComponent(entity)}`,
+    );
+  }
+
+  /** Query entity evolution over time. */
+  async graphEvolution(params?: Record<string, string>): Promise<unknown> {
+    return this.request("GET", "/api/v1/graph/evolution", undefined, params);
+  }
+
+  /** Graph health check. */
+  async graphHealth(): Promise<unknown> {
+    return this.request("GET", "/api/v1/graph/health");
+  }
+
+  // ── Codebase ─────────────────────────────────────────
+
+  /** Ingest a project directory. */
+  async codebaseIngest(input: CodebaseIngestInput): Promise<unknown> {
+    return this.request("POST", "/api/v1/codebase/ingest", input);
+  }
+
+  /** Verify project manifest integrity. */
+  async codebaseVerify(projectDir: string): Promise<unknown> {
+    return this.request("POST", "/api/v1/codebase/verify", { projectDir });
+  }
+
+  /** Semantic code search. */
+  async codebaseSearch(params: CodebaseSearchParams): Promise<unknown> {
+    return this.request("GET", "/api/v1/codebase/search", undefined, {
+      query: params.query,
+      projectId: params.projectId,
+      type: params.type,
+      limit: this.toStr(params.limit),
+    });
+  }
+
+  /** Query temporal commit timeline. */
+  async codebaseTimeline(
+    params?: CodebaseTimelineParams,
+  ): Promise<unknown> {
+    return this.request("GET", "/api/v1/codebase/timeline", undefined, {
+      projectId: params?.projectId,
+      filePath: params?.filePath,
+      limit: this.toStr(params?.limit),
+    });
+  }
+
+  /** List all ingested projects. */
+  async codebaseProjects(): Promise<unknown> {
+    return this.request("GET", "/api/v1/codebase/projects");
+  }
+
+  /** Delete a project by ID. */
+  async codebaseProjectDelete(id: string): Promise<unknown> {
+    return this.request(
+      "DELETE",
+      `/api/v1/codebase/projects/${encodeURIComponent(id)}`,
+    );
+  }
+
+  // ── Knowledge ────────────────────────────────────────
+
+  /** Full-text knowledge search. */
+  async knowledgeSearch(input: KnowledgeSearchInput): Promise<unknown> {
+    return this.request("POST", "/api/v1/knowledge/search", input);
+  }
+
+  /** Ingest a knowledge entry. */
+  async knowledgeIngest(input: KnowledgeIngestInput): Promise<unknown> {
+    return this.request("POST", "/api/v1/knowledge/ingest", input);
+  }
+
+  // ── Diagnostics ──────────────────────────────────────
+
+  /** Ingest SARIF diagnostics. */
+  async diagnosticsIngest(input: DiagnosticsIngestInput): Promise<unknown> {
+    return this.request("POST", "/api/v1/diagnostics/ingest", input);
+  }
+
+  /** Get latest diagnostics run. */
+  async diagnosticsLatest(
+    params?: DiagnosticsLatestParams,
+  ): Promise<unknown> {
+    return this.request("GET", "/api/v1/diagnostics/latest", undefined, {
+      projectId: params?.projectId,
+      toolName: params?.toolName,
+    });
+  }
+
+  /** List findings for a specific analysis. */
+  async diagnosticsList(analysisId: string): Promise<unknown> {
+    return this.request(
+      "GET",
+      `/api/v1/diagnostics/findings/${encodeURIComponent(analysisId)}`,
+    );
+  }
+
+  /** Compare two analyses (introduced/resolved/unchanged). */
+  async diagnosticsDiff(input: DiagnosticsDiffInput): Promise<unknown> {
+    return this.request("POST", "/api/v1/diagnostics/diff", input);
+  }
+
+  /** Get summary for an analysis. */
+  async diagnosticsSummary(analysisId: string): Promise<unknown> {
+    return this.request(
+      "GET",
+      `/api/v1/diagnostics/summary/${encodeURIComponent(analysisId)}`,
+    );
+  }
+
+  /** Compare diagnostics across tools. */
+  async diagnosticsCompare(
+    params: DiagnosticsCompareParams,
+  ): Promise<unknown> {
+    return this.request("GET", "/api/v1/diagnostics/compare", undefined, {
+      projectId: params.projectId,
+      treeHash: params.treeHash,
+      toolNames: params.toolNames,
+    });
+  }
+
+  /** Group findings by symbol. */
+  async diagnosticsBySymbol(
+    params: DiagnosticsBySymbolParams,
+  ): Promise<unknown> {
+    return this.request("GET", "/api/v1/diagnostics/by-symbol", undefined, {
+      analysisId: params.analysisId,
+      groupBy: params.groupBy,
+    });
+  }
+
+  /** LLM-powered summarize for an analysis. */
+  async diagnosticsSummarize(
+    analysisId: string,
+    body?: { useLLM?: boolean },
+  ): Promise<unknown> {
+    return this.request(
+      "POST",
+      `/api/v1/diagnostics/summarize/${encodeURIComponent(analysisId)}`,
+      body,
+    );
+  }
+
+  // ── Agents ───────────────────────────────────────────
+
+  /** Register or update an agent identity. */
+  async agentRegister(input: AgentRegisterInput): Promise<unknown> {
+    return this.request("POST", "/api/v1/agents/register", input);
+  }
+
+  /** Get quota status for agents. */
+  async agentQuotas(agentId?: string): Promise<unknown> {
+    return this.request("GET", "/api/v1/agents/quotas", undefined, {
+      agentId,
+    });
+  }
+
+  /** Deregister an agent. */
+  async agentDeregister(agentId: string): Promise<unknown> {
+    return this.request(
+      "DELETE",
+      `/api/v1/agents/${encodeURIComponent(agentId)}`,
+    );
+  }
+
+  // ── Memory ───────────────────────────────────────────
+
+  /** Get memory statistics. */
+  async memoryStats(): Promise<unknown> {
+    return this.request("GET", "/api/v1/memory/stats");
+  }
+
+  /** Consolidate/compress memories. */
+  async memoryConsolidate(input?: MemoryConsolidateInput): Promise<unknown> {
+    return this.request("POST", "/api/v1/memory/consolidate", input);
+  }
+
+  /** Subscribe to memory events. */
+  async memorySubscribe(body: unknown): Promise<unknown> {
+    return this.request("POST", "/api/v1/memory/subscribe", body);
+  }
+
+  /** Unsubscribe from memory events. */
+  async memoryUnsubscribe(body: unknown): Promise<unknown> {
+    return this.request("POST", "/api/v1/memory/unsubscribe", body);
+  }
+
+  /** Compress memories into digest facts. */
+  async memoryCompress(body: unknown): Promise<unknown> {
+    return this.request("POST", "/api/v1/memory/compress", body);
+  }
+
+  // ── Worklog ──────────────────────────────────────────
+
+  /** Record a worklog event. */
+  async worklogRecord(input: WorklogRecordInput): Promise<unknown> {
+    return this.request("POST", "/api/v1/worklog", input);
+  }
+
+  /** List worklog events. */
+  async worklogList(limit?: number): Promise<unknown> {
+    return this.request("GET", "/api/v1/worklog", undefined, {
+      limit: this.toStr(limit),
+    });
+  }
+
+  // ── Causal ───────────────────────────────────────────
+
+  /** Search for causes of an entity. */
+  async causalCauses(params: CausalSearchParams): Promise<unknown> {
+    return this.request("GET", "/api/v1/causal/causes", undefined, {
+      entity: params.entity,
+      projectId: params.projectId,
+      limit: this.toStr(params.limit),
+    });
+  }
+
+  /** Search for effects of an entity. */
+  async causalEffects(params: CausalSearchParams): Promise<unknown> {
+    return this.request("GET", "/api/v1/causal/effects", undefined, {
+      entity: params.entity,
+      projectId: params.projectId,
+      limit: this.toStr(params.limit),
+    });
+  }
+
+  /** Get causal chain between two entities. */
+  async causalChain(params: CausalChainParams): Promise<unknown> {
+    return this.request("GET", "/api/v1/causal/chain", undefined, {
+      from: params.from,
+      to: params.to,
+      projectId: params.projectId,
+    });
+  }
+
+  /** Trigger causal discovery. */
+  async causalDiscover(input: CausalDiscoverInput): Promise<unknown> {
+    return this.request("POST", "/api/v1/causal/discover", input);
+  }
+
+  // ── Tools ────────────────────────────────────────────
+
+  /** List available MCP tools. */
+  async toolsList(): Promise<unknown> {
+    return this.request("GET", "/api/v1/tools");
+  }
+
+  /** Get schema for a specific tool. */
+  async toolsGet(name: string): Promise<unknown> {
+    return this.request("GET", `/api/v1/tools/${encodeURIComponent(name)}`);
+  }
+
+  /** Invoke a tool by name. */
+  async toolsInvoke(
+    name: string,
+    args?: Record<string, unknown>,
+  ): Promise<unknown> {
+    return this.request(
+      "POST",
+      `/api/v1/tools/${encodeURIComponent(name)}/invoke`,
+      { arguments: args },
+    );
+  }
+}
+
+/** Error thrown when the API returns a non-2xx status. */
+export class PingMemError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(status: number, message: string, body: unknown) {
+    super(message);
+    this.name = "PingMemError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/** Convenience factory for creating a PingMemSDK instance. */
+export function createClient(config: PingMemSDKConfig): PingMemSDK {
+  return new PingMemSDK(config);
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,0 +1,26 @@
+export type {
+  PingMemSDKConfig,
+  ErrorResponse,
+  SessionStartInput,
+  SessionEndInput,
+  ContextSaveInput,
+  ContextSearchParams,
+  CodebaseIngestInput,
+  CodebaseSearchParams,
+  CodebaseTimelineParams,
+  KnowledgeIngestInput,
+  KnowledgeSearchInput,
+  DiagnosticsLatestParams,
+  DiagnosticsDiffInput,
+  DiagnosticsIngestInput,
+  DiagnosticsCompareParams,
+  DiagnosticsBySymbolParams,
+  AgentRegisterInput,
+  WorklogRecordInput,
+  MemoryConsolidateInput,
+  CausalSearchParams,
+  CausalChainParams,
+  CausalDiscoverInput,
+} from "./types.js";
+
+export { PingMemSDK, createClient } from "./client.js";

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -1,0 +1,168 @@
+/** SDK configuration options. */
+export interface PingMemSDKConfig {
+  /** Base URL of the ping-mem REST server (e.g. "http://localhost:3000"). */
+  baseUrl: string;
+  /** Optional Bearer token or API key for authenticated requests. */
+  apiKey?: string | undefined;
+  /** Optional custom headers merged into every request. */
+  headers?: Record<string, string> | undefined;
+}
+
+/** Standard error response from the REST API. */
+export interface ErrorResponse {
+  error: string;
+  message: string;
+}
+
+/** Options for SDK request methods (internal). */
+export interface RequestOptions {
+  method: string;
+  path: string;
+  body?: unknown;
+  params?: Record<string, string | undefined>;
+}
+
+// ── Session ──────────────────────────────────────────────
+
+export interface SessionStartInput {
+  name: string;
+  projectDir?: string | undefined;
+  autoIngest?: boolean | undefined;
+}
+
+export interface SessionEndInput {
+  sessionId: string;
+}
+
+// ── Context ──────────────────────────────────────────────
+
+export interface ContextSaveInput {
+  key: string;
+  value: string;
+  category?: string | undefined;
+  priority?: string | undefined;
+  tags?: string[] | undefined;
+}
+
+export interface ContextSearchParams {
+  query: string;
+  limit?: number | undefined;
+  category?: string | undefined;
+}
+
+// ── Codebase ─────────────────────────────────────────────
+
+export interface CodebaseIngestInput {
+  projectDir: string;
+  forceReingest?: boolean | undefined;
+}
+
+export interface CodebaseSearchParams {
+  query: string;
+  projectId?: string | undefined;
+  type?: string | undefined;
+  limit?: number | undefined;
+}
+
+export interface CodebaseTimelineParams {
+  projectId?: string | undefined;
+  filePath?: string | undefined;
+  limit?: number | undefined;
+}
+
+// ── Knowledge ────────────────────────────────────────────
+
+export interface KnowledgeIngestInput {
+  projectId: string;
+  title: string;
+  solution: string;
+  symptoms?: string[] | undefined;
+  rootCause?: string | undefined;
+  tags?: string[] | undefined;
+}
+
+export interface KnowledgeSearchInput {
+  query: string;
+  projectId?: string | undefined;
+  crossProject?: boolean | undefined;
+  tags?: string[] | undefined;
+  limit?: number | undefined;
+}
+
+// ── Diagnostics ──────────────────────────────────────────
+
+export interface DiagnosticsLatestParams {
+  projectId?: string | undefined;
+  toolName?: string | undefined;
+}
+
+export interface DiagnosticsDiffInput {
+  analysisIdA: string;
+  analysisIdB: string;
+}
+
+export interface DiagnosticsIngestInput {
+  projectId: string;
+  treeHash: string;
+  toolName: string;
+  toolVersion: string;
+  configHash: string;
+  sarif: unknown;
+}
+
+export interface DiagnosticsCompareParams {
+  projectId: string;
+  treeHash: string;
+  toolNames: string;
+}
+
+export interface DiagnosticsBySymbolParams {
+  analysisId: string;
+  groupBy?: string | undefined;
+}
+
+// ── Agent ────────────────────────────────────────────────
+
+export interface AgentRegisterInput {
+  agentId: string;
+  role: string;
+  admin?: boolean | undefined;
+  ttlMs?: number | undefined;
+  quotaBytes?: number | undefined;
+  quotaCount?: number | undefined;
+}
+
+// ── Worklog ──────────────────────────────────────────────
+
+export interface WorklogRecordInput {
+  kind: string;
+  title: string;
+  status?: string | undefined;
+  toolName?: string | undefined;
+  durationMs?: number | undefined;
+}
+
+// ── Memory ───────────────────────────────────────────────
+
+export interface MemoryConsolidateInput {
+  maxItems?: number | undefined;
+}
+
+// ── Causal ───────────────────────────────────────────────
+
+export interface CausalSearchParams {
+  entity: string;
+  projectId?: string | undefined;
+  limit?: number | undefined;
+}
+
+export interface CausalChainParams {
+  from: string;
+  to: string;
+  projectId?: string | undefined;
+}
+
+export interface CausalDiscoverInput {
+  projectId: string;
+  scope?: string | undefined;
+}

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts"
+  ]
+}

--- a/src/http/routes/openapi.ts
+++ b/src/http/routes/openapi.ts
@@ -54,5 +54,7 @@ function generate(): Record<string, unknown> {
   return { openapi: "3.1.0", info: { title: "ping-mem REST API", version: "2.0.0", description: "Universal Memory Layer for AI agents." }, servers: [{ url: "http://localhost:3000", description: "Local" }], paths, components: { securitySchemes: { ApiKeyAuth: { type: "apiKey", in: "header", name: "X-API-Key" }, BearerAuth: { type: "http", scheme: "bearer" } }, schemas: { ErrorResponse: { type: "object", properties: { error: { type: "string" }, message: { type: "string" } }, required: ["error", "message"] } } }, security: [{ ApiKeyAuth: [] }, { BearerAuth: [] }] };
 }
 
+export function generateOpenAPISpec(): Record<string, unknown> { return generate(); }
+
 let cached: Record<string, unknown> | null = null;
 export function registerOpenAPIRoute(app: Hono<AppEnv>): void { app.get("/openapi.json", (c) => { if (!cached) cached = generate(); return c.json(cached); }); }


### PR DESCRIPTION
## Summary
Phase 4 of the CLI/REST plan — TypeScript SDK generated from OpenAPI spec.

- `sdk/typescript/` — zero-dependency thin client (`PingMemSDK` class)
- Covers all REST endpoints: session, context, codebase, knowledge, diagnostics, agents, memory, worklog, causal, graph, tools
- Typed interfaces for all operations in `types.ts`
- OpenAPI spec extraction: `scripts/extract-openapi.ts`
- 51 SDK tests

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] 51 SDK tests pass
- [x] No regressions to existing tests

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)