### PR TITLE
arch: single-owner MCP proxy — eliminate dual-process DB access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,11 @@ bun run dist/mcp/cli.js  # MCP stdio
 
 Routes: `/ui` `/ui/memories` `/ui/diagnostics` `/ui/ingestion` `/ui/agents` `/ui/knowledge` `/ui/sessions` `/ui/events` `/ui/worklog` `/ui/mining` `/ui/insights` `/ui/profile` `/admin`
 
+## MCP Transport Modes
+
+- **Proxy mode** (recommended): `PING_MEM_REST_URL=http://localhost:3003 bun run dist/mcp/proxy-cli.js` — all tools proxy through Docker, no DB opened in the MCP process
+- **Direct mode** (deprecated): `bun run dist/mcp/cli.js` — opens DB directly, concurrent access issues with Docker
+
 ## Deployment
 
 | Environment | Endpoint | Credentials |

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "start:sse": "PING_MEM_TRANSPORT=sse bun run dist/http/index.js",
     "start:rest": "PING_MEM_TRANSPORT=rest bun run dist/http/index.js",
     "start:mcp": "bun run dist/mcp/cli.js",
+    "start:proxy": "bun run dist/mcp/proxy-cli.js",
     "setup": "bash scripts/setup.sh",
     "setup:docker": "docker compose up -d",
     "setup:docker-only": "bash scripts/setup.sh --docker-only",

--- a/src/http/rest-server.ts
+++ b/src/http/rest-server.ts
@@ -3467,16 +3467,21 @@ export class RESTPingMemServer {
           writeLockManager: this.writeLockManager,
         };
 
+        const { StructuralToolModule } = await import("../mcp/handlers/StructuralToolModule.js");
+        const { MiningToolModule } = await import("../mcp/handlers/MiningToolModule.js");
+
         const modules = [
           new ContextToolModule(state),
           new GraphToolModule(state),
           new WorklogToolModule(state),
           new DiagnosticsToolModule(state),
           new CodebaseToolModule(state),
+          new StructuralToolModule(state),
           new MemoryToolModule(state),
           new CausalToolModule(state),
           new KnowledgeToolModule(state),
           new AgentToolModule(state),
+          new MiningToolModule(state),
         ];
 
         const args = parseResult.data.args;

--- a/src/mcp/PingMemServer.ts
+++ b/src/mcp/PingMemServer.ts
@@ -383,6 +383,9 @@ export class PingMemServer {
  * Start the server if running as main module
  */
 export async function main(): Promise<void> {
+  if (!process.env.PING_MEM_REST_URL) {
+    console.error("[DEPRECATED] Running MCP in direct-DB mode. Set PING_MEM_REST_URL for proxy mode.");
+  }
   const runtimeConfig = loadRuntimeConfig();
   const services = await createRuntimeServices();
   const diagnosticsDbPath = process.env.PING_MEM_DIAGNOSTICS_DB_PATH;

--- a/src/mcp/__tests__/proxy-cli.test.ts
+++ b/src/mcp/__tests__/proxy-cli.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Tests for src/mcp/proxy-cli.ts
+ *
+ * Verifies:
+ * 1. proxy-cli.ts has no direct DB imports (grep test)
+ * 2. tool-schemas.ts has no direct DB imports (grep test)
+ * 3. proxyToolCall function with mocked fetch
+ * 4. checkDockerHealth function
+ * 5. Error formatting
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { readFileSync } from "fs";
+import path from "path";
+import { TOOLS } from "../tool-schemas.js";
+
+// ============================================================================
+// Static imports analysis (grep tests)
+// ============================================================================
+
+const WORKTREE = path.resolve(import.meta.dir, "../../..");
+const PROXY_CLI_PATH = path.join(WORKTREE, "src/mcp/proxy-cli.ts");
+const TOOL_SCHEMAS_PATH = path.join(WORKTREE, "src/mcp/tool-schemas.ts");
+
+describe("proxy-cli.ts — no DB imports", () => {
+  it("should not have import statements for Database", () => {
+    const content = readFileSync(PROXY_CLI_PATH, "utf-8");
+    // Check for actual import statements (lines starting with "import"), not comments
+    const importLines = content.split("\n").filter((line) => line.trimStart().startsWith("import"));
+    const importText = importLines.join("\n");
+    expect(importText).not.toMatch(/Database/);
+    expect(importText).not.toMatch(/bun:sqlite/);
+  });
+
+  it("should not have import statements for EventStore", () => {
+    const content = readFileSync(PROXY_CLI_PATH, "utf-8");
+    const importLines = content.split("\n").filter((line) => line.trimStart().startsWith("import"));
+    const importText = importLines.join("\n");
+    expect(importText).not.toMatch(/EventStore/);
+  });
+
+  it("should not have import statements for MemoryManager", () => {
+    const content = readFileSync(PROXY_CLI_PATH, "utf-8");
+    const importLines = content.split("\n").filter((line) => line.trimStart().startsWith("import"));
+    const importText = importLines.join("\n");
+    expect(importText).not.toMatch(/MemoryManager/);
+  });
+
+  it("should not have import statements for SessionManager", () => {
+    const content = readFileSync(PROXY_CLI_PATH, "utf-8");
+    const importLines = content.split("\n").filter((line) => line.trimStart().startsWith("import"));
+    const importText = importLines.join("\n");
+    expect(importText).not.toMatch(/SessionManager/);
+  });
+
+  it("should use PING_MEM_REST_URL env var", () => {
+    const content = readFileSync(PROXY_CLI_PATH, "utf-8");
+    expect(content).toMatch(/PING_MEM_REST_URL/);
+  });
+
+  it("should import from tool-schemas.js (not PingMemServer)", () => {
+    const content = readFileSync(PROXY_CLI_PATH, "utf-8");
+    expect(content).toMatch(/from.*tool-schemas/);
+    expect(content).not.toMatch(/import.*TOOLS.*from.*PingMemServer/);
+  });
+});
+
+describe("tool-schemas.ts — no DB imports", () => {
+  it("should have zero import statements total (pure static file)", () => {
+    const content = readFileSync(TOOL_SCHEMAS_PATH, "utf-8");
+    const importLines = content.split("\n").filter((line) => line.trimStart().startsWith("import"));
+    // tool-schemas.ts should have NO import statements at all (it's a pure data file)
+    expect(importLines).toHaveLength(0);
+  });
+
+  it("should not reference storage, memory, or graph modules in any line", () => {
+    const content = readFileSync(TOOL_SCHEMAS_PATH, "utf-8");
+    expect(content).not.toMatch(/from.*\.\.\/storage\//);
+    expect(content).not.toMatch(/from.*\.\.\/memory\//);
+    expect(content).not.toMatch(/from.*\.\.\/graph\//);
+    expect(content).not.toMatch(/from.*bun:sqlite/);
+  });
+});
+
+// ============================================================================
+// TOOLS array
+// ============================================================================
+
+describe("TOOLS static array", () => {
+  it("should contain at least 40 tools", () => {
+    expect(TOOLS.length).toBeGreaterThanOrEqual(40);
+  });
+
+  it("should have context_session_start", () => {
+    const tool = TOOLS.find((t) => t.name === "context_session_start");
+    expect(tool).toBeDefined();
+    expect(tool?.inputSchema.required).toContain("name");
+  });
+
+  it("should have context_auto_recall", () => {
+    const tool = TOOLS.find((t) => t.name === "context_auto_recall");
+    expect(tool).toBeDefined();
+    expect(tool?.inputSchema.required).toContain("query");
+  });
+
+  it("should have context_save with required key and value", () => {
+    const tool = TOOLS.find((t) => t.name === "context_save");
+    expect(tool).toBeDefined();
+    expect(tool?.inputSchema.required).toContain("key");
+    expect(tool?.inputSchema.required).toContain("value");
+  });
+
+  it("should have all tool categories", () => {
+    const names = TOOLS.map((t) => t.name);
+    // Context
+    expect(names).toContain("context_session_start");
+    expect(names).toContain("context_search");
+    // Graph
+    expect(names).toContain("context_hybrid_search");
+    expect(names).toContain("context_get_lineage");
+    // Worklog
+    expect(names).toContain("worklog_record");
+    // Diagnostics
+    expect(names).toContain("diagnostics_ingest");
+    // Codebase
+    expect(names).toContain("codebase_ingest");
+    expect(names).toContain("codebase_search");
+    // Structural
+    expect(names).toContain("codebase_impact");
+    // Memory
+    expect(names).toContain("memory_maintain");
+    // Causal
+    expect(names).toContain("search_causes");
+    // Knowledge
+    expect(names).toContain("knowledge_search");
+    // Agent
+    expect(names).toContain("agent_register");
+    // Mining
+    expect(names).toContain("transcript_mine");
+    expect(names).toContain("dreaming_run");
+  });
+
+  it("all tools should have valid inputSchema", () => {
+    for (const tool of TOOLS) {
+      expect(tool.name).toBeTruthy();
+      expect(tool.description).toBeTruthy();
+      expect(tool.inputSchema.type).toBe("object");
+      expect(typeof tool.inputSchema.properties).toBe("object");
+    }
+  });
+
+  it("should have no duplicate tool names", () => {
+    const names = TOOLS.map((t) => t.name);
+    const unique = new Set(names);
+    expect(unique.size).toBe(names.length);
+  });
+});
+
+// ============================================================================
+// proxyToolCall — with mocked fetch
+// ============================================================================
+
+describe("proxyToolCall", () => {
+  // Import the functions after module-level await completes
+  // We use dynamic import to avoid running the top-level await startup code
+  // Instead, test the logic by importing only the exported functions
+
+  it("should return content on success", async () => {
+    // Mock global fetch
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () =>
+      new Response(JSON.stringify({ data: { sessionId: "test-123", name: "test" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    try {
+      // Dynamically import to get the function without running top-level startup
+      const { proxyToolCall } = await import("../proxy-cli.js");
+      const result = await proxyToolCall(
+        "context_session_start",
+        { name: "test" },
+        "http://localhost:3003",
+        undefined
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe("text");
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.sessionId).toBe("test-123");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("should return isError on HTTP error", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () =>
+      new Response(
+        JSON.stringify({ error: "NOT_FOUND", message: "Tool not found" }),
+        { status: 404, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    try {
+      const { proxyToolCall } = await import("../proxy-cli.js");
+      const result = await proxyToolCall(
+        "nonexistent_tool",
+        {},
+        "http://localhost:3003",
+        undefined
+      );
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.status).toBe(404);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("should return isError on network error", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => {
+      throw new Error("Connection refused");
+    });
+
+    try {
+      const { proxyToolCall } = await import("../proxy-cli.js");
+      const result = await proxyToolCall(
+        "context_search",
+        { query: "test" },
+        "http://localhost:3003",
+        undefined
+      );
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toBe("PROXY_NETWORK_ERROR");
+      expect(parsed.hint).toMatch(/docker/i);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("should include auth header when provided", async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedHeaders: Record<string, string> | undefined;
+
+    globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+      capturedHeaders = init?.headers as Record<string, string>;
+      return new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    try {
+      const { proxyToolCall } = await import("../proxy-cli.js");
+      await proxyToolCall(
+        "context_status",
+        {},
+        "http://localhost:3003",
+        "Basic dXNlcjpwYXNz"
+      );
+
+      expect(capturedHeaders?.["Authorization"]).toBe("Basic dXNlcjpwYXNz");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// ============================================================================
+// checkDockerHealth
+// ============================================================================
+
+describe("checkDockerHealth", () => {
+  it("should return true when health endpoint responds OK", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () =>
+      new Response(JSON.stringify({ status: "ok" }), { status: 200 })
+    );
+
+    try {
+      const { checkDockerHealth } = await import("../proxy-cli.js");
+      const result = await checkDockerHealth("http://localhost:3003");
+      expect(result).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("should return false when health endpoint is unreachable", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+
+    try {
+      const { checkDockerHealth } = await import("../proxy-cli.js");
+      const result = await checkDockerHealth("http://localhost:9999");
+      expect(result).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("should return false when health endpoint returns non-OK status", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () =>
+      new Response("Internal Server Error", { status: 500 })
+    );
+
+    try {
+      const { checkDockerHealth } = await import("../proxy-cli.js");
+      const result = await checkDockerHealth("http://localhost:3003");
+      expect(result).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/src/mcp/proxy-cli.ts
+++ b/src/mcp/proxy-cli.ts
@@ -1,0 +1,199 @@
+/**
+ * MCP stdio REST proxy for ping-mem.
+ *
+ * This is a thin proxy that forwards MCP tool calls to the Docker REST server.
+ * It has ZERO imports from Database, EventStore, MemoryManager, or any service classes.
+ * All tool state is owned by the Docker process; this process is stateless.
+ *
+ * Configuration via environment variables:
+ *   PING_MEM_REST_URL    Base URL for the Docker REST server (default: http://localhost:3003)
+ *   PING_MEM_ADMIN_USER  HTTP Basic Auth username (optional)
+ *   PING_MEM_ADMIN_PASS  HTTP Basic Auth password (optional)
+ *
+ * @module mcp/proxy-cli
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { TOOLS } from "./tool-schemas.js";
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const BASE_URL = process.env.PING_MEM_REST_URL ?? "http://localhost:3003";
+const ADMIN_USER = process.env.PING_MEM_ADMIN_USER ?? "";
+const ADMIN_PASS = process.env.PING_MEM_ADMIN_PASS ?? "";
+
+const AUTH_HEADER =
+  ADMIN_USER
+    ? "Basic " + Buffer.from(`${ADMIN_USER}:${ADMIN_PASS}`).toString("base64")
+    : undefined;
+
+// ============================================================================
+// Health check
+// ============================================================================
+
+/** Check if the Docker ping-mem REST server is reachable */
+export async function checkDockerHealth(baseUrl: string): Promise<boolean> {
+  try {
+    const resp = await fetch(`${baseUrl}/health`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    return resp.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Attempt to start Docker ping-mem service (fire-and-forget) */
+export async function tryStartDocker(): Promise<void> {
+  try {
+    const proc = Bun.spawn(["docker", "compose", "up", "-d", "ping-mem"], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    // Don't await — fire and forget so proxy startup is not blocked
+    proc.exited.catch(() => {
+      // Ignore errors — Docker may not be installed or compose file may not exist
+    });
+  } catch {
+    // Ignore — docker command not available
+  }
+}
+
+// ============================================================================
+// Tool call proxy
+// ============================================================================
+
+/** Proxy a single MCP tool call to the Docker REST server */
+export async function proxyToolCall(
+  name: string,
+  args: Record<string, unknown>,
+  baseUrl: string,
+  authHeader?: string
+): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (authHeader) {
+    headers["Authorization"] = authHeader;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(
+      `${baseUrl}/api/v1/tools/${encodeURIComponent(name)}/invoke`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ args }),
+        signal: AbortSignal.timeout(30_000),
+      }
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const isTimeout = message.includes("timed out") || message.includes("timeout");
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            error: isTimeout ? "PROXY_TIMEOUT" : "PROXY_NETWORK_ERROR",
+            message,
+            hint: `Is ping-mem Docker running at ${baseUrl}? Try: docker compose up -d ping-mem`,
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            error: "PROXY_PARSE_ERROR",
+            message: `HTTP ${response.status} — could not parse response body`,
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  if (!response.ok) {
+    const body = json as Record<string, unknown>;
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            error: body["error"] ?? "PROXY_HTTP_ERROR",
+            message: body["message"] ?? `HTTP ${response.status}`,
+            status: response.status,
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const body = json as Record<string, unknown>;
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(body["data"] ?? body, null, 2),
+      },
+    ],
+  };
+}
+
+// ============================================================================
+// MCP Server
+// ============================================================================
+
+const server = new Server(
+  { name: "ping-mem", version: "1.0.0" },
+  { capabilities: { tools: { listChanged: true } } }
+);
+
+// List tools: serve static schemas locally (no HTTP round-trip)
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: TOOLS,
+}));
+
+// Call tool: proxy to Docker REST
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+  return proxyToolCall(name, (args as Record<string, unknown>) ?? {}, BASE_URL, AUTH_HEADER);
+});
+
+// ============================================================================
+// Startup
+// ============================================================================
+
+const isHealthy = await checkDockerHealth(BASE_URL);
+if (!isHealthy) {
+  process.stderr.write(
+    `[ping-mem proxy] WARNING: Docker REST server not reachable at ${BASE_URL}. ` +
+    `Tool calls will fail until Docker is up.\n` +
+    `Attempting: docker compose up -d ping-mem ...\n`
+  );
+  await tryStartDocker();
+} else {
+  process.stderr.write(`[ping-mem proxy] Connected to ${BASE_URL}\n`);
+}
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/src/mcp/tool-schemas.ts
+++ b/src/mcp/tool-schemas.ts
@@ -1,0 +1,1012 @@
+/**
+ * Static tool schema definitions for the MCP proxy.
+ *
+ * This file has ZERO imports from storage, memory, graph, or any service classes.
+ * It exists so the proxy-cli.ts can import tool schemas without transitively
+ * pulling in Database, EventStore, MemoryManager, or any other service.
+ *
+ * IMPORTANT: When adding or modifying tools, keep this file in sync with
+ * the corresponding handler modules in ./handlers/.
+ *
+ * @module mcp/tool-schemas
+ */
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+// ============================================================================
+// Context Tools (from ContextToolModule.ts)
+// ============================================================================
+
+const CONTEXT_TOOLS: ToolDefinition[] = [
+  {
+    name: "context_session_start",
+    description: "Start a new memory session with optional configuration. If projectDir is provided with autoIngest=true, automatically ingests the project codebase.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Session name" },
+        projectDir: { type: "string", description: "Project directory for context isolation and automatic code ingestion" },
+        continueFrom: { type: "string", description: "Session ID to continue from" },
+        defaultChannel: { type: "string", description: "Default channel for memories" },
+        autoIngest: { type: "boolean", description: "Automatically ingest project codebase when projectDir is provided (default: false)" },
+        agentId: { type: "string", description: "Agent identity for multi-agent scoping (stored in session metadata)" },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "context_session_end",
+    description: "End the current session",
+    inputSchema: {
+      type: "object",
+      properties: {
+        reason: { type: "string", description: "Reason for ending session" },
+      },
+    },
+  },
+  {
+    name: "context_save",
+    description: "Save a memory item with key-value pair, optionally extracting entities for knowledge graph",
+    inputSchema: {
+      type: "object",
+      properties: {
+        key: { type: "string", description: "Unique key for the memory" },
+        value: { type: "string", description: "Memory content" },
+        category: {
+          type: "string",
+          enum: ["task", "decision", "progress", "note", "error", "warning", "fact", "observation"],
+          description: "Memory category",
+        },
+        priority: {
+          type: "string",
+          enum: ["high", "normal", "low"],
+          description: "Priority level",
+        },
+        channel: { type: "string", description: "Channel for organization" },
+        metadata: { type: "object", description: "Custom metadata" },
+        extractEntities: {
+          type: "boolean",
+          description: "Entity extraction is ON by default. Set false to skip extraction.",
+        },
+        skipProactiveRecall: {
+          type: "boolean",
+          description: "When true, skip proactive recall of related memories on save (default: false)",
+        },
+        agentScope: {
+          type: "string",
+          enum: ["private", "role", "shared", "public"],
+          description: "Visibility scope for multi-agent access control (default: public)",
+        },
+      },
+      required: ["key", "value"],
+    },
+  },
+  {
+    name: "context_get",
+    description: "Retrieve memories by key or query parameters",
+    inputSchema: {
+      type: "object",
+      properties: {
+        key: { type: "string", description: "Exact key to retrieve" },
+        keyPattern: { type: "string", description: "Wildcard pattern for keys" },
+        category: { type: "string", description: "Filter by category" },
+        channel: { type: "string", description: "Filter by channel" },
+        limit: { type: "number", description: "Maximum results" },
+        offset: { type: "number", description: "Pagination offset" },
+      },
+    },
+  },
+  {
+    name: "context_search",
+    description: "Semantic search for relevant memories",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query" },
+        minSimilarity: { type: "number", description: "Minimum similarity score (0-1)" },
+        category: { type: "string", description: "Filter by category" },
+        channel: { type: "string", description: "Filter by channel" },
+        limit: { type: "number", description: "Maximum results" },
+        compact: { type: "boolean", description: "When true, return snippets (first 80 chars) instead of full memory values" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "context_delete",
+    description: "Delete a memory by key",
+    inputSchema: {
+      type: "object",
+      properties: {
+        key: { type: "string", description: "Key of memory to delete" },
+      },
+      required: ["key"],
+    },
+  },
+  {
+    name: "context_checkpoint",
+    description: "Create a checkpoint of current session state",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Checkpoint name" },
+        description: { type: "string", description: "Checkpoint description" },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "context_status",
+    description: "Get current session status and statistics",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "context_session_list",
+    description: "List recent sessions",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: { type: "number", description: "Maximum sessions to return" },
+      },
+    },
+  },
+  {
+    name: "context_auto_recall",
+    description:
+      "Deterministic memory recall for pre-prompt context injection. " +
+      "Returns formatted context from relevant memories matching the query. " +
+      "Designed for hook-driven or instruction-driven recall — call before processing any substantive user message.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "The user's message or keywords to search for relevant memories",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of memories to return (default: 5)",
+        },
+        minScore: {
+          type: "number",
+          description: "Minimum relevance score threshold 0-1 (default: 0.1)",
+        },
+      },
+      required: ["query"],
+    },
+  },
+];
+
+// ============================================================================
+// Graph Tools (from GraphToolModule.ts)
+// ============================================================================
+
+const GRAPH_TOOLS: ToolDefinition[] = [
+  {
+    name: "context_query_relationships",
+    description: "Query relationships for an entity",
+    inputSchema: {
+      type: "object",
+      properties: {
+        entityId: { type: "string", description: "Entity ID or name to query" },
+        depth: { type: "number", description: "Maximum traversal depth (default: 1)" },
+        relationshipTypes: {
+          type: "array",
+          items: { type: "string" },
+          description: "Filter by relationship types",
+        },
+        direction: {
+          type: "string",
+          enum: ["incoming", "outgoing", "both"],
+          description: "Relationship direction",
+        },
+      },
+      required: ["entityId"],
+    },
+  },
+  {
+    name: "context_hybrid_search",
+    description: "Hybrid search combining semantic, keyword, and graph search",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query" },
+        limit: { type: "number", description: "Maximum results" },
+        weights: {
+          type: "object",
+          properties: {
+            semantic: { type: "number", description: "Weight for semantic search (0-1)" },
+            keyword: { type: "number", description: "Weight for keyword search (0-1)" },
+            graph: { type: "number", description: "Weight for graph search (0-1)" },
+          },
+          description: "Weights for different search modes",
+        },
+        sessionId: { type: "string", description: "Filter by session" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "context_get_lineage",
+    description: "Get upstream/downstream lineage for an entity",
+    inputSchema: {
+      type: "object",
+      properties: {
+        entityId: { type: "string", description: "Entity ID to trace" },
+        direction: {
+          type: "string",
+          enum: ["upstream", "downstream", "both"],
+          description: "Direction of lineage traversal",
+        },
+        maxDepth: { type: "number", description: "Maximum traversal depth" },
+      },
+      required: ["entityId"],
+    },
+  },
+  {
+    name: "context_query_evolution",
+    description: "Query temporal evolution of an entity",
+    inputSchema: {
+      type: "object",
+      properties: {
+        entityId: { type: "string", description: "Entity ID" },
+        startTime: { type: "string", description: "ISO date start" },
+        endTime: { type: "string", description: "ISO date end" },
+      },
+      required: ["entityId"],
+    },
+  },
+  {
+    name: "context_health",
+    description: "Check ping-mem service health and connectivity to Neo4j, Qdrant, and SQLite",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+];
+
+// ============================================================================
+// Worklog Tools (from WorklogToolModule.ts)
+// ============================================================================
+
+const WORKLOG_TOOLS: ToolDefinition[] = [
+  {
+    name: "worklog_record",
+    description: "Record a deterministic worklog event (tool, diagnostics, git, task)",
+    inputSchema: {
+      type: "object",
+      properties: {
+        kind: {
+          type: "string",
+          enum: ["tool", "diagnostics", "git", "task"],
+          description: "Worklog category",
+        },
+        title: { type: "string", description: "Short title for the event" },
+        status: {
+          type: "string",
+          enum: ["success", "failed", "partial"],
+          description: "Outcome status",
+        },
+        phase: {
+          type: "string",
+          enum: ["started", "summary", "completed"],
+          description: "Task phase (only for kind=task)",
+        },
+        toolName: { type: "string", description: "Tool name" },
+        toolVersion: { type: "string", description: "Tool version" },
+        configHash: { type: "string", description: "Deterministic config hash" },
+        environmentHash: { type: "string", description: "Environment hash" },
+        projectId: { type: "string", description: "Project ID" },
+        treeHash: { type: "string", description: "Tree hash" },
+        commitHash: { type: "string", description: "Commit hash" },
+        runId: { type: "string", description: "Diagnostics run ID" },
+        command: { type: "string", description: "Command executed" },
+        durationMs: { type: "number", description: "Duration in milliseconds" },
+        summary: { type: "string", description: "Summary of outcome" },
+        metadata: { type: "object", description: "Additional metadata" },
+        sessionId: { type: "string", description: "Explicit session ID (optional)" },
+      },
+      required: ["kind", "title"],
+    },
+  },
+  {
+    name: "worklog_list",
+    description: "List worklog events for a session",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: { type: "string", description: "Session ID (optional)" },
+        limit: { type: "number", description: "Max events to return" },
+        eventTypes: {
+          type: "array",
+          items: { type: "string" },
+          description: "Filter by event types",
+        },
+      },
+    },
+  },
+];
+
+// ============================================================================
+// Diagnostics Tools (from DiagnosticsToolModule.ts)
+// ============================================================================
+
+const DIAGNOSTICS_TOOLS: ToolDefinition[] = [
+  {
+    name: "diagnostics_ingest",
+    description: "Ingest diagnostics results (SARIF 2.1.0 or normalized findings).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectId: { type: "string", description: "Project ID" },
+        treeHash: { type: "string", description: "Tree hash" },
+        commitHash: { type: "string", description: "Optional commit hash" },
+        toolName: { type: "string", description: "Tool name (optional if SARIF provides it)" },
+        toolVersion: { type: "string", description: "Tool version (optional if SARIF provides it)" },
+        configHash: { type: "string", description: "Deterministic config hash" },
+        environmentHash: { type: "string", description: "Environment hash" },
+        status: {
+          type: "string",
+          enum: ["passed", "failed", "partial"],
+          description: "Run status",
+        },
+        durationMs: { type: "number", description: "Duration in milliseconds" },
+        sarif: { type: ["object", "string"], description: "SARIF 2.1.0 payload" },
+        findings: {
+          type: "array",
+          description: "Normalized findings (optional alternative to SARIF)",
+          items: { type: "object" },
+        },
+        metadata: { type: "object", description: "Additional metadata" },
+      },
+      required: ["projectId", "treeHash", "configHash"],
+    },
+  },
+  {
+    name: "diagnostics_latest",
+    description: "Get latest diagnostics run for a project/tool/treeHash.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectId: { type: "string", description: "Project ID" },
+        toolName: { type: "string", description: "Tool name" },
+        toolVersion: { type: "string", description: "Tool version" },
+        treeHash: { type: "string", description: "Tree hash" },
+      },
+      required: ["projectId"],
+    },
+  },
+  {
+    name: "diagnostics_list",
+    description: "List findings for a specific analysisId.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        analysisId: { type: "string", description: "Analysis ID" },
+      },
+      required: ["analysisId"],
+    },
+  },
+  {
+    name: "diagnostics_diff",
+    description: "Diff two analyses by analysisId.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        analysisIdA: { type: "string", description: "Base analysis ID" },
+        analysisIdB: { type: "string", description: "Compare analysis ID" },
+      },
+      required: ["analysisIdA", "analysisIdB"],
+    },
+  },
+  {
+    name: "diagnostics_summary",
+    description: "Summarize findings for a specific analysisId.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        analysisId: { type: "string", description: "Analysis ID" },
+      },
+      required: ["analysisId"],
+    },
+  },
+  {
+    name: "diagnostics_compare_tools",
+    description: "Compare diagnostics across multiple tools for the same project state (treeHash).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectId: { type: "string", description: "Project ID" },
+        treeHash: { type: "string", description: "Tree hash" },
+        toolNames: {
+          type: "array",
+          items: { type: "string" },
+          description: "Filter by specific tool names (optional)",
+        },
+      },
+      required: ["projectId", "treeHash"],
+    },
+  },
+  {
+    name: "diagnostics_by_symbol",
+    description: "Group diagnostic findings by symbol.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        analysisId: { type: "string", description: "Analysis ID" },
+        groupBy: {
+          type: "string",
+          enum: ["symbol", "file"],
+          description: "Group by symbol or file (default: symbol)",
+        },
+      },
+      required: ["analysisId"],
+    },
+  },
+  {
+    name: "diagnostics_summarize",
+    description: "Generate or retrieve LLM-powered summary of diagnostic findings.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        analysisId: { type: "string", description: "Analysis ID" },
+        useLLM: {
+          type: "boolean",
+          description: "Use LLM to generate summary (default: false for raw findings)",
+        },
+        forceRefresh: {
+          type: "boolean",
+          description: "Bypass cache and regenerate summary (default: false)",
+        },
+      },
+      required: ["analysisId"],
+    },
+  },
+];
+
+// ============================================================================
+// Codebase Tools (from CodebaseToolModule.ts)
+// ============================================================================
+
+const CODEBASE_TOOLS: ToolDefinition[] = [
+  {
+    name: "codebase_ingest",
+    description: "Ingest a project codebase: scan files, extract chunks, index git history, persist to graph+vectors. Deterministic and reproducible.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectDir: { type: "string", description: "Absolute path to project root" },
+        forceReingest: { type: "boolean", description: "Force re-ingestion even if no changes detected" },
+        maxCommits: { type: "number", description: "Max git commits to ingest (default 200). Lower for cloned repos you don't own." },
+      },
+      required: ["projectDir"],
+    },
+  },
+  {
+    name: "codebase_verify",
+    description: "Verify that the ingested manifest matches the current on-disk project state. Returns validation result.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectDir: { type: "string", description: "Absolute path to project root" },
+      },
+      required: ["projectDir"],
+    },
+  },
+  {
+    name: "codebase_search",
+    description: "Search code chunks semantically using deterministic vectors. Returns relevant code snippets with provenance.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Natural language query" },
+        projectId: { type: "string", description: "Filter by project ID" },
+        filePath: { type: "string", description: "Filter by file path" },
+        type: {
+          type: "string",
+          enum: ["code", "comment", "docstring"],
+          description: "Filter by chunk type",
+        },
+        limit: { type: "number", description: "Maximum results (default: 10)" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "codebase_timeline",
+    description: "Query temporal timeline for a project or file. Returns commits with explicit-only 'why' (from commit messages, issue refs, ADRs).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectId: { type: "string", description: "Project ID" },
+        filePath: { type: "string", description: "Optional: filter by specific file" },
+        limit: { type: "number", description: "Maximum commits to return (default: 100)" },
+      },
+      required: ["projectId"],
+    },
+  },
+  {
+    name: "codebase_list_projects",
+    description: "List all ingested projects with metadata (file/chunk/commit counts). Returns project info sorted by lastIngestedAt (default), filesCount, or rootPath.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectId: { type: "string", description: "Optional: filter by specific project ID" },
+        limit: { type: "number", description: "Maximum projects to return (1-1000, default: 100)" },
+        sortBy: {
+          type: "string",
+          description: "Sort field: 'lastIngestedAt' (default), 'filesCount', or 'rootPath'",
+          enum: ["lastIngestedAt", "filesCount", "rootPath"],
+        },
+      },
+    },
+  },
+  {
+    name: "project_delete",
+    description: "Delete all memory, diagnostics, graph, and vectors for a project directory",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectDir: { type: "string", description: "Absolute path to project root" },
+      },
+      required: ["projectDir"],
+    },
+  },
+];
+
+// ============================================================================
+// Structural Tools (from StructuralToolModule.ts)
+// ============================================================================
+
+const STRUCTURAL_TOOLS: ToolDefinition[] = [
+  {
+    name: "codebase_impact",
+    description:
+      "Impact analysis: find all files that would be affected by changing the given file. " +
+      "Traverses the reverse import graph to find upstream dependents. " +
+      "Returns files sorted by distance (closest dependents first).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectId: {
+          type: "string",
+          description: "Project ID (from codebase_list_projects)",
+        },
+        filePath: {
+          type: "string",
+          description: "File path (relative to project root) to analyze impact for",
+        },
+        maxDepth: {
+          type: "number",
+          description: "Maximum traversal depth (default: 5, max: 10)",
+        },
+      },
+      required: ["projectId", "filePath"],
+    },
+  },
+  {
+    name: "codebase_blast_radius",
+    description:
+      "Blast radius: find all files that are transitively depended upon by the given file. " +
+      "Traverses the forward import graph to find all downstream dependencies.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectId: {
+          type: "string",
+          description: "Project ID (from codebase_list_projects)",
+        },
+        filePath: {
+          type: "string",
+          description: "File path (relative to project root) to analyze",
+        },
+        maxDepth: {
+          type: "number",
+          description: "Maximum traversal depth (default: 5, max: 10)",
+        },
+      },
+      required: ["projectId", "filePath"],
+    },
+  },
+  {
+    name: "codebase_dependency_map",
+    description:
+      "Full dependency map: return the import graph for a project as an adjacency list. " +
+      "Shows which files import which other files, with symbol names.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectId: {
+          type: "string",
+          description: "Project ID (from codebase_list_projects)",
+        },
+        includeExternal: {
+          type: "boolean",
+          description: "Include external (node_modules) dependencies (default: false)",
+        },
+      },
+      required: ["projectId"],
+    },
+  },
+];
+
+// ============================================================================
+// Memory Tools (from MemoryToolModule.ts)
+// ============================================================================
+
+const MEMORY_TOOLS: ToolDefinition[] = [
+  {
+    name: "memory_stats",
+    description: "Show relevance decay distribution, stale count, total tracked memories, and average relevance score",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "memory_consolidate",
+    description: "Archive stale memories (low relevance, old access) into digest entries. Groups by channel/category, creates summaries, and moves originals to archived_memories table.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        maxScore: { type: "number", description: "Maximum relevance score for consolidation (default: 0.3)" },
+        minDaysOld: { type: "number", description: "Minimum days since last access (default: 30)" },
+      },
+    },
+  },
+  {
+    name: "memory_subscribe",
+    description: "Subscribe to real-time memory change events (save, update, delete). Returns a subscriptionId for later unsubscription.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        channel: { type: "string", description: "Filter events by channel" },
+        category: { type: "string", description: "Filter events by category" },
+      },
+    },
+  },
+  {
+    name: "memory_unsubscribe",
+    description: "Unsubscribe from memory change events using a subscriptionId.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        subscriptionId: { type: "string", description: "Subscription ID returned from memory_subscribe" },
+      },
+      required: ["subscriptionId"],
+    },
+  },
+  {
+    name: "memory_compress",
+    description: "Compress stale memories into digest entries using LLM (when available) or heuristic deduplication. Returns extracted facts and compression ratio.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        channel: { type: "string", description: "Compress memories in this channel only" },
+        category: { type: "string", description: "Compress memories in this category only" },
+        maxCount: { type: "number", description: "Maximum number of memories to compress (default: 100)" },
+      },
+    },
+  },
+  {
+    name: "memory_maintain",
+    description: "Run full maintenance cycle: dedup near-duplicates, consolidate stale memories, prune low-relevance unused memories, vacuum WAL. Supports dryRun preview mode.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        dryRun: { type: "boolean", description: "Preview what would be done without modifying (default: false)" },
+        dedupThreshold: { type: "number", description: "Similarity threshold for dedup (default: 0.95)" },
+        pruneThreshold: { type: "number", description: "Relevance threshold below which memories are pruned (default: 0.2)" },
+        pruneMinAgeDays: { type: "number", description: "Minimum age in days for pruning (default: 30)" },
+        exportDir: { type: "string", description: "Directory to export high-relevance memories as native markdown files" },
+      },
+    },
+  },
+  {
+    name: "memory_conflicts",
+    description: "List or resolve memory contradictions. Lists memories flagged with contradiction metadata, or resolves a specific contradiction by ID.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        action: {
+          type: "string",
+          description: "Action: 'list' (default) to show unresolved contradictions, 'resolve' to mark one as resolved",
+          enum: ["list", "resolve"],
+        },
+        memoryId: { type: "string", description: "Memory ID to resolve (required when action is 'resolve')" },
+      },
+    },
+  },
+];
+
+// ============================================================================
+// Causal Tools (from CausalToolModule.ts)
+// ============================================================================
+
+const CAUSAL_TOOLS: ToolDefinition[] = [
+  {
+    name: "search_causes",
+    description: "Find what causes a given entity. Returns entities that have CAUSES relationships pointing to the target. Note: entity name resolution is not yet implemented — entityId is required.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Entity name or concept (for reference only; entityId is required)" },
+        entityId: { type: "string", description: "Entity ID to find causes for (required)" },
+        limit: { type: "number", description: "Maximum results (default: 10)" },
+      },
+      required: ["entityId"],
+    },
+  },
+  {
+    name: "search_effects",
+    description: "Find what a given entity causes/affects. Returns entities that are effects of the source. Note: entity name resolution is not yet implemented — entityId is required.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Entity name or concept (for reference only; entityId is required)" },
+        entityId: { type: "string", description: "Entity ID to find effects for (required)" },
+        limit: { type: "number", description: "Maximum results (default: 10)" },
+      },
+      required: ["entityId"],
+    },
+  },
+  {
+    name: "get_causal_chain",
+    description: "Find the causal chain between two entities. Returns the shortest path of CAUSES relationships.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        startEntityId: { type: "string", description: "Starting entity ID" },
+        endEntityId: { type: "string", description: "Ending entity ID" },
+      },
+      required: ["startEntityId", "endEntityId"],
+    },
+  },
+  {
+    name: "trigger_causal_discovery",
+    description: "Trigger LLM-based causal relationship discovery on provided text. Extracts cause-effect pairs and optionally persists them.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        text: { type: "string", description: "Text to analyze for causal relationships" },
+        persist: { type: "boolean", description: "Whether to persist discovered links to the graph (default: false)" },
+      },
+      required: ["text"],
+    },
+  },
+];
+
+// ============================================================================
+// Knowledge Tools (from KnowledgeToolModule.ts)
+// ============================================================================
+
+const KNOWLEDGE_TOOLS: ToolDefinition[] = [
+  {
+    name: "knowledge_search",
+    description:
+      "Search knowledge entries using full-text search. Supports cross-project queries and tag filtering.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Full-text search query",
+        },
+        projectId: {
+          type: "string",
+          description: "Filter results to this project ID",
+        },
+        crossProject: {
+          type: "boolean",
+          description: "If true, search across all projects (default: false)",
+        },
+        tags: {
+          type: "array",
+          description: "Filter by tags (entries must contain all specified tags)",
+          items: { type: "string" },
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results (default: 20)",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "knowledge_ingest",
+    description:
+      "Ingest a knowledge entry (upsert). ID is deterministically computed from projectId + title.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectId: {
+          type: "string",
+          description: "Project identifier for scoping",
+        },
+        title: {
+          type: "string",
+          description: "Title of the knowledge entry (used for deduplication)",
+        },
+        solution: {
+          type: "string",
+          description: "The solution or answer",
+        },
+        symptoms: {
+          type: "string",
+          description: "Observable symptoms or indicators",
+        },
+        rootCause: {
+          type: "string",
+          description: "Root cause analysis",
+        },
+        tags: {
+          type: "array",
+          description: "Tags for categorization",
+          items: { type: "string" },
+        },
+      },
+      required: ["projectId", "title", "solution"],
+    },
+  },
+];
+
+// ============================================================================
+// Agent Tools (from AgentToolModule.ts)
+// ============================================================================
+
+const AGENT_TOOLS: ToolDefinition[] = [
+  {
+    name: "agent_register",
+    description:
+      "Register or update an agent identity with quota and TTL. Upserts into the agent_quotas table.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agentId: {
+          type: "string",
+          description: "Unique agent identifier (1-256 characters)",
+        },
+        role: {
+          type: "string",
+          description: 'Free-form agent role (e.g. "researcher", "coder", "reviewer")',
+        },
+        admin: {
+          type: "boolean",
+          description: "Whether this agent has admin privileges (default: false)",
+        },
+        ttlMs: {
+          type: "number",
+          description: "Time-to-live for registration in milliseconds (default: 86400000 = 24h)",
+        },
+        quotaBytes: {
+          type: "number",
+          description: "Maximum memory storage in bytes (default: 10485760 = 10MB)",
+        },
+        quotaCount: {
+          type: "number",
+          description: "Maximum number of memory entries (default: 10000)",
+        },
+        metadata: {
+          type: "object",
+          description: "Arbitrary metadata attached to this agent",
+        },
+      },
+      required: ["agentId", "role"],
+    },
+  },
+  {
+    name: "agent_quota_status",
+    description:
+      "Get current quota usage for a registered agent. Returns bytes/count consumed and limits.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agentId: {
+          type: "string",
+          description: "Agent identifier to query",
+        },
+      },
+      required: ["agentId"],
+    },
+  },
+  {
+    name: "agent_deregister",
+    description: "Remove an agent registration and release all its write locks.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agentId: {
+          type: "string",
+          description: "Agent identifier to deregister",
+        },
+      },
+      required: ["agentId"],
+    },
+  },
+];
+
+// ============================================================================
+// Mining Tools (from MiningToolModule.ts)
+// ============================================================================
+
+const MINING_TOOLS: ToolDefinition[] = [
+  {
+    name: "transcript_mine",
+    description:
+      "Scan Claude Code transcript files (~/.claude/projects/) to extract user facts and save them as memories. " +
+      "Respects mining_progress state to avoid reprocessing already-mined sessions.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: {
+          type: "number",
+          description: "Maximum number of sessions to process per run (default: 10)",
+        },
+        project: {
+          type: "string",
+          description: "Restrict mining to transcripts from a specific project directory name",
+        },
+      },
+    },
+  },
+  {
+    name: "dreaming_run",
+    description:
+      "Run a dreaming cycle: deduce implicit facts from memory clusters, generalize patterns into " +
+      "personality traits, and invalidate stale derived insights. Requires an active session.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        dream: {
+          type: "boolean",
+          description: "Set to true to trigger the dreaming cycle (default: true)",
+        },
+      },
+    },
+  },
+  {
+    name: "insights_list",
+    description:
+      "List derived insights — memories with category='derived_insight' produced by the dreaming engine.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: {
+          type: "number",
+          description: "Maximum number of insights to return (default: 20)",
+        },
+      },
+    },
+  },
+];
+
+// ============================================================================
+// Aggregated TOOLS array — same order as PingMemServer.ts
+// ============================================================================
+
+export const TOOLS: ToolDefinition[] = [
+  ...CONTEXT_TOOLS,
+  ...GRAPH_TOOLS,
+  ...WORKLOG_TOOLS,
+  ...DIAGNOSTICS_TOOLS,
+  ...CODEBASE_TOOLS,
+  ...STRUCTURAL_TOOLS,
+  ...MEMORY_TOOLS,
+  ...CAUSAL_TOOLS,
+  ...KNOWLEDGE_TOOLS,
+  ...AGENT_TOOLS,
+  ...MINING_TOOLS,
+];


### PR DESCRIPTION
## Summary

Converts MCP stdio from direct-DB access to REST proxy. All agents (Claude Code, hooks, u-os, understory) now go through one Docker process that owns the database. Eliminates concurrent SQLite access, stale sessions, and cross-process search failures.

**Before**: Two processes fighting over one database
**After**: One process, one truth, all clients proxy through it

- New `src/mcp/proxy-cli.ts` (~130 lines) — thin MCP-to-REST translator
- Static tool schemas in `src/mcp/tool-schemas.ts` — zero service imports
- Fixed `/invoke` handler missing MiningToolModule + StructuralToolModule
- Auto-starts Docker if not running, clear error messages

Fixes #89

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] `bun test` — 2173/2173 pass (22 new proxy tests)
- [x] MCP proxy lists 53 tools
- [ ] Full E2E: proxy save → search round-trip
- [ ] Agent-path audit after deploy

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Proxy mode for MCP tool invocation, enabling tools to be proxied through Docker while keeping the database external to the MCP process.
  * Added new `start:proxy` command to launch proxy mode with automatic Docker health checks.

* **Documentation**
  * Added MCP Transport Modes documentation describing Proxy mode and Direct mode (deprecated due to concurrent access issues).

* **Tests**
  * Added comprehensive test suite for proxy functionality, including tool registry validation and end-to-end proxy handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->