### PR TITLE
fix: collect-diagnostics CI — timeout + push-to-main only trigger (#128)

### DIFF
--- a/.github/workflows/diagnostics.yml
+++ b/.github/workflows/diagnostics.yml
@@ -2,9 +2,7 @@ name: Diagnostics Collection
 
 on:
   push:
-    branches: ["main", "develop"]
-  pull_request:
-    branches: ["main", "develop"]
+    branches: ["main"]
 
 jobs:
   collect-diagnostics:
@@ -73,6 +71,7 @@ jobs:
           echo "Qdrant failed to start" && exit 1
 
       - name: Ingest codebase
+        timeout-minutes: 10
         env:
           NEO4J_URI: bolt://localhost:7687
           NEO4J_USERNAME: neo4j


### PR DESCRIPTION
Hardens the CI workflow to prevent hangs and unnecessary PR runs:

- Adds 10-minute timeout to diagnostics ingest step (avoids infinite hang when Ollama unavailable)
- Restricts workflow to push events on main branch only (removes PR trigger)

Closes #128